### PR TITLE
Check commands only run if check path is invalid

### DIFF
--- a/examples/.gitignore
+++ b/examples/.gitignore
@@ -1,2 +1,3 @@
 path-exists
 .hushlogin
+*.txt

--- a/examples/.scope/caching-on-files.yaml
+++ b/examples/.scope/caching-on-files.yaml
@@ -1,0 +1,22 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: caching-on-files
+  description: Check if status.txt contains 'ready', fix if not
+spec:
+  include: when-required
+  actions:
+    - name: cache-example
+      description: |
+        Check if status.txt contains 'ready', fix if not.
+      check:
+        paths:
+          - status.txt
+        commands:
+          # this only runs if status.txt changes or doesn't exist
+          # you can prove that by changing 'ready' to anything else
+          # once this has been run once
+          - grep -q 'ready' status.txt
+      fix:
+        commands:
+          - bash -c 'echo ready > status.txt'


### PR DESCRIPTION
The behavior of checks with both paths and commands was unintuitive. 
Previously, the command would always run and the check would always fail if the path cache was invalidated.

In practice, this has never been the desired behavior and it has led to us avoiding caching on paths. 
What we've actually wanted is to only run the `check.command` only if the `path` file has been changed.

As an example, imagine we want to upload an ssh pub key to GitHub. 
We only want to do that if the pub key isn't in GitHub, but we also don't want to even bother checking ("expensive" network call) if the pub key hasn't changed since the last time the `action` was run.

The `--no-cache` flag was also problematic for actions with both paths and checks. Passing the --no-cache flag ensured the fix always ran, even if the check command was successful. That is also not desired behavior because it makes it more complex than necessary to write fixes that duplicate the check logic to ensure idempotency.

The new behavior:
- When a check has _only_ a path, the fix will run whenever the file doesn't exist, has changed, or the --no-cache flag has been passed.
- When a check has _only_ a command, the fix will run when the check command fails.
- When a check has _both_ a path _and_ command, the command will only run when the path cache is invalid (or --no-cache is specified) and then the fix will only run if both the path cache is invalid _and_ the check command fails.

This _is_ a breaking change in theory.  
I audited our internal usage and there was only one instance of us using both `path` and `command` in a `check` and, if anything, it will behave better after this change is made.