### PR TITLE
Upgrade toolchain to latest stable

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.82.0"
+channel = "stable"
 components = ["clippy", "rustfmt"]
 targets = ["x86_64-apple-darwin", "aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]

--- a/scope/src/bin/scope.rs
+++ b/scope/src/bin/scope.rs
@@ -118,7 +118,7 @@ async fn exec_sub_command(found_config: &FoundConfig, args: &[String]) -> Result
     let command = match args.first() {
         None => return Err(anyhow::anyhow!("Sub command not provided")),
         Some(cmd) => {
-            format!("scope-{}", cmd)
+            format!("scope-{cmd}")
         }
     };
     let _ = std::mem::replace(&mut args[0], command);
@@ -171,10 +171,7 @@ async fn print_commands(found_config: &FoundConfig) {
             let command_name = command.file_name().unwrap().to_str().unwrap().to_string();
             let command_name = command_name.replace("scope-", "");
             command_map.entry(command_name.clone()).or_insert_with(|| {
-                format!(
-                    "External sub-command, run `scope {}` for help",
-                    command_name
-                )
+                format!("External sub-command, run `scope {command_name}` for help")
             });
         }
         for command in Cli::command().get_subcommands() {

--- a/scope/src/doctor/check.rs
+++ b/scope/src/doctor/check.rs
@@ -1457,7 +1457,7 @@ pub(crate) mod tests {
                     &DoctorCommands::from_commands(
                         Path::new("/some/dir"),
                         "/some/working/dir",
-                        &vec!["touch ~/.somefile".to_string()],
+                        &["touch ~/.somefile".to_string()],
                     )
                     .unwrap(),
                 )

--- a/scope/src/doctor/runner.rs
+++ b/scope/src/doctor/runner.rs
@@ -231,7 +231,7 @@ where
                 "otel.name" = format!("group {}", group_name)
             );
             group_span.pb_set_length(group_container.actions.len() as u64);
-            group_span.pb_set_message(&format!("group {}", group_name));
+            group_span.pb_set_message(&format!("group {group_name}"));
             let _span = group_span.enter();
 
             let group_result = self.execute_group(&group_span, group_container).await?;
@@ -435,7 +435,7 @@ async fn print_pretty_result(
     let task_reports = action_task_reports_for_display(&result.action_report);
     for task in task_reports {
         if let Some(text) = task.output {
-            let line_prefix = format!("{}/{}", group_name, action_name);
+            let line_prefix = format!("{group_name}/{action_name}");
             for line in text.lines() {
                 let output_line = format!("{}:  {}", line_prefix.dimmed(), line);
                 report_stdout!("{}", output_line);

--- a/scope/src/lint/mod.rs
+++ b/scope/src/lint/mod.rs
@@ -103,7 +103,7 @@ pub mod commands {
         };
 
         ActionReport {
-            action_name: format!("{} {}", prefix, idx),
+            action_name: format!("{prefix} {idx}"),
             check: vec![action_report()],
             fix: vec![action_report()],
             validate: vec![action_report(), action_report()],
@@ -111,7 +111,7 @@ pub mod commands {
     }
 
     fn make_group(offset: i64) -> GroupReport {
-        let group_name = format!("group {}", offset);
+        let group_name = format!("group {offset}");
         let mut group = GroupReport::new(&group_name);
         group.add_action(&make_action_report(&group_name, offset * 10 + 1));
         group.add_action(&make_action_report(&group_name, offset * 10 + 2));

--- a/scope/src/models/mod.rs
+++ b/scope/src/models/mod.rs
@@ -140,7 +140,7 @@ where
     if let Err(_first_error) = validator.validate(&parsed_json) {
         println!("{}", serde_json::to_string_pretty(&parsed_json).unwrap());
         for e in validator.iter_errors(&parsed_json) {
-            println!("error: {}", e);
+            println!("error: {e}");
         }
         unreachable!();
     };
@@ -173,7 +173,7 @@ mod schema_gen {
         let mut schema_gen = crate::models::make_schema_generator();
         let merged_schema = schema_gen.root_schema_for::<ScopeTypes>();
         let merged_schema_json = serde_json::to_string_pretty(&merged_schema).unwrap();
-        std::fs::write(format!("{}/merged.json", out_dir), &merged_schema_json).unwrap();
+        std::fs::write(format!("{out_dir}/merged.json"), &merged_schema_json).unwrap();
 
         V1AlphaReportLocation::create_and_validate(&mut schema_gen, &out_dir, &merged_schema_json)
             .unwrap();

--- a/scope/src/shared/capture.rs
+++ b/scope/src/shared/capture.rs
@@ -76,7 +76,7 @@ impl<R: io::AsyncRead + Unpin> StreamCapture<R> {
                     _ => info!("{}", line),
                 },
                 OutputDestination::StandardOut => {
-                    writeln!(self.writer.write().await, "{}\r", line).ok();
+                    writeln!(self.writer.write().await, "{line}\r").ok();
                 }
                 OutputDestination::StandardOutWithPrefix(prefix) => {
                     writeln!(
@@ -224,7 +224,7 @@ impl OutputCapture {
             .iter()
             .map(|(time, line)| {
                 let offset: Duration = *time - self.start_time;
-                (*time, format!("{} OUT: {}", offset, line))
+                (*time, format!("{offset} OUT: {line}"))
             })
             .collect();
 
@@ -233,7 +233,7 @@ impl OutputCapture {
             .iter()
             .map(|(time, line)| {
                 let offset: Duration = *time - self.start_time;
-                (*time, format!("{} ERR: {}", offset, line))
+                (*time, format!("{offset} ERR: {line}"))
             })
             .collect();
 

--- a/scope/src/shared/config_load.rs
+++ b/scope/src/shared/config_load.rs
@@ -52,7 +52,7 @@ impl ConfigOptions {
         let id = nanoid::nanoid!(4, &nanoid::alphabet::SAFE);
         let now = chrono::Local::now();
         let current_time = now.format("%Y%m%d");
-        format!("{}-{}", current_time, id)
+        format!("{current_time}-{id}")
     }
     pub fn get_run_id(&self) -> String {
         self.run_id.clone().unwrap_or_else(Self::generate_run_id)

--- a/scope/src/shared/logging.rs
+++ b/scope/src/shared/logging.rs
@@ -316,15 +316,12 @@ impl LoggingOpts {
     }
 
     pub async fn configure_logging(&self, run_id: &str, prefix: &str) -> ConfiguredLogger {
-        let file_name = format!("scope-{}-{}.log", prefix, run_id);
-        let full_file_name = format!("/tmp/scope/{}", file_name);
+        let file_name = format!("scope-{prefix}-{run_id}.log");
+        let full_file_name = format!("/tmp/scope/{file_name}");
         std::fs::create_dir_all("/tmp/scope").expect("to be able to create tmp dir");
 
         let otel_props = self.setup_otel(run_id).unwrap_or_else(|e| {
-            println!(
-                "opentelemetry configuration failed. Events will not be sent. {:?}",
-                e
-            );
+            println!("opentelemetry configuration failed. Events will not be sent. {e:?}");
             None
         });
 

--- a/scope/src/shared/mod.rs
+++ b/scope/src/shared/mod.rs
@@ -59,7 +59,7 @@ where
         let mut description = resource.description().to_string();
         if description.len() > 55 {
             description.truncate(55);
-            description = format!("{}...", description);
+            description = format!("{description}...");
         }
 
         let mut loc = resource.metadata().file_path();

--- a/scope/src/shared/models/internal/command.rs
+++ b/scope/src/shared/models/internal/command.rs
@@ -109,7 +109,7 @@ mod tests {
     #[test]
     fn from_commands_inserts_execution_path() {
         let base_path = Path::new("/foo/bar");
-        let input = vec!["echo 'foo'", "baz/qux", "./qux"];
+        let input = ["echo 'foo'", "baz/qux", "./qux"];
 
         let actual = DoctorCommands::from_commands(
             base_path,
@@ -129,7 +129,7 @@ mod tests {
     fn from_commands_inserts_working_dir() {
         let containing_dir = Path::new("/foo/bar");
         let working_dir = "/some/working_dir";
-        let commands = vec!["{{ working_dir }}/foo.sh", "./bar.sh"]
+        let commands = ["{{ working_dir }}/foo.sh", "./bar.sh"]
             .iter()
             .map(|cmd| cmd.to_string())
             .collect::<Vec<String>>();
@@ -325,7 +325,7 @@ mod tests {
 
             // Currently, the tilde is NOT expanded, but we want it to be
             let home_dir = std::env::var("HOME").expect("HOME environment variable should be set");
-            let expected = DoctorCommand::from_str(&format!("{}/script.sh", home_dir));
+            let expected = DoctorCommand::from_str(&format!("{home_dir}/script.sh"));
             assert_eq!(expected, actual);
         }
 
@@ -340,10 +340,8 @@ mod tests {
 
             // Currently, the tildes are NOT expanded, but we want them to be
             let home_dir = std::env::var("HOME").expect("HOME environment variable should be set");
-            let expected = DoctorCommand::from_str(&format!(
-                "cp {}/source.txt {}/dest.txt",
-                home_dir, home_dir
-            ));
+            let expected =
+                DoctorCommand::from_str(&format!("cp {home_dir}/source.txt {home_dir}/dest.txt"));
             assert_eq!(expected, actual);
         }
     }

--- a/scope/src/shared/models/internal/fix.rs
+++ b/scope/src/shared/models/internal/fix.rs
@@ -107,7 +107,7 @@ mod tests {
     #[test]
     fn from_spec_translates_to_fix() {
         let spec = DoctorFixSpec {
-            commands: vec![
+            commands: [
                 "some/command",
                 "./other_command",
                 "{{ working_dir }}/.foo.sh",

--- a/scope/src/shared/models/internal/mod.rs
+++ b/scope/src/shared/models/internal/mod.rs
@@ -145,7 +145,7 @@ mod tests {
             let working_dir = "/some/path";
             let command = "{{ working_dir }}/foo.sh";
 
-            let actual = substitute_templates(&working_dir, &command).unwrap();
+            let actual = substitute_templates(working_dir, command).unwrap();
 
             assert_eq!("/some/path/foo.sh".to_string(), actual)
         }
@@ -155,7 +155,7 @@ mod tests {
             let working_dir = "/some/path";
             let command = "./foo.sh";
 
-            let actual = substitute_templates(&working_dir, &command).unwrap();
+            let actual = substitute_templates(working_dir, command).unwrap();
 
             assert_eq!("./foo.sh".to_string(), actual)
         }
@@ -167,7 +167,7 @@ mod tests {
             let working_dir = "/some/path";
             let command = "{{ not_a_thing }}/foo.sh";
 
-            let actual = substitute_templates(&working_dir, &command).unwrap();
+            let actual = substitute_templates(working_dir, command).unwrap();
 
             assert_eq!("/foo.sh".to_string(), actual)
         }

--- a/scope/src/shared/report.rs
+++ b/scope/src/shared/report.rs
@@ -44,7 +44,7 @@ impl ReportUploadLocationDestination {
             ReportUploadLocationDestination::Local { destination } => {
                 let id = nanoid::nanoid!(10, &nanoid::alphabet::SAFE);
                 fs::create_dir_all(destination)?;
-                let file_path = format!("{}/scope-{}.md", destination, id);
+                let file_path = format!("{destination}/scope-{id}.md");
                 let mut file = File::create(&file_path)?;
                 file.write_all(report.as_bytes())?;
 


### PR DESCRIPTION
`std::env::home_dir()` is deprecated in v1.82 because it was broken on Windows, but instead of removing it, it was fixed in v1.85.

Moving us to the latest stable toolchain (v1.88 at time of writing).

This did require fixing a couple of lints
- https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
- https://rust-lang.github.io/rust-clippy/master/index.html#useless_vec

The useless_vec fix wasn't strictly _required_ but it came along for the ride when I ran `clippy cargo --fix`