### PR TITLE
ci: Trigger Pages deploy from Release workflow

### DIFF
--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+When modifying any workflow file in this directory, update README.md to reflect the changes. This includes the mermaid diagram, the workflow table, and the notes section.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,51 @@
+# CI Workflows
+
+```mermaid
+flowchart LR
+    PR["Pull Request"] -->|"*.rs, Cargo.*"| Tests
+    PR -->|"docs/**"| Docs
+
+    Push["Push to main"] --> Release
+    Manual["Manual dispatch"] --> Release
+
+    subgraph Tests["Tests Workflow"]
+        T1["build, check, test, fmt, clippy<br/><i>ubuntu-latest</i>"]
+    end
+
+    subgraph Docs["Docs Workflow"]
+        D1["Build docs via workflow_call"]
+    end
+
+    subgraph Release["Release Workflow"]
+        direction TB
+        R1["Prepare Release<br/><i>ubuntu-latest</i>"]
+        R2["Push Release Branch + Tag<br/><i>gusto-ubuntu</i>"]
+        R3["Build 4 targets in parallel<br/><i>ubuntu-latest + macos-latest</i>"]
+        R4["Create GitHub Release<br/><i>gusto-ubuntu</i>"]
+        R5["Deploy GitHub Pages<br/><i>ubuntu-latest</i>"]
+        R1 --> R2 --> R3 --> R4 --> R5
+    end
+
+    subgraph Pages["Build Github Pages"]
+        direction TB
+        P1["Build Docusaurus site"] --> P2["Deploy to Pages"]
+    end
+
+    Docs --> Pages
+    R5 --> Pages
+```
+
+## Workflow files
+
+| File | Trigger | What it does |
+|---|---|---|
+| `test.yml` | PR (Rust/Cargo files) | cargo build, check, test, fmt, clippy |
+| `docs.yml` | PR (docs/ files) | Calls `gh-page.yml` to verify docs build |
+| `release.yml` | Push to main, manual dispatch | CalVer stamp, cross-compile 4 targets, create GitHub release, deploy Pages |
+| `gh-page.yml` | `workflow_call` only | Build Docusaurus site and deploy to GitHub Pages |
+
+## Notes
+
+- **Runner split**: Most jobs use GitHub-hosted runners (`ubuntu-latest`, `macos-latest`). Jobs that need write access (git push, release creation) use `gusto-ubuntu-default` due to the Gusto org IP allow list.
+- **Version format**: CalVer `YEAR.MONTH.DAY+HHMM` (e.g., `2026.4.7+1823`). The `+HHMM` build metadata is ignored by Cargo for version comparison but ensures unique tags. See the comment in `release.yml` for details.
+- **Pages deployment**: Triggered by the Release workflow via `workflow_call`, not by tag patterns.

--- a/.github/workflows/gh-page.yml
+++ b/.github/workflows/gh-page.yml
@@ -1,9 +1,6 @@
 name: Build Github Pages
 
 on:
-  push:
-    tags:
-      - '**[0-9]+.[0-9]+.[0-9]+*'
   workflow_call:
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -161,3 +161,8 @@ jobs:
             --title "v${VERSION}" \
             --notes "" \
             artifacts/*.tar.gz
+
+  pages:
+    name: Deploy Github Pages
+    needs: release
+    uses: ./.github/workflows/gh-page.yml

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   // favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://Gusto.github.io/',
+  url: 'https://docs.gusto.com',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/scope',

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,14 +8,14 @@ const config: Config = {
   // favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
-  url: 'https://oscope-dev.github.io/',
+  url: 'https://Gusto.github.io/',
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/scope',
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'oscope-dev', // Usually your GitHub org/user name.
+  organizationName: 'Gusto', // Usually your GitHub org/user name.
   projectName: 'scope', // Usually your repo name.
 
   onBrokenLinks: 'throw',
@@ -41,7 +41,7 @@ const config: Config = {
           // Please change this to your repo.
           // Remove this to remove the "edit this page" links.
           editUrl:
-            'https://github.com/oscope-dev/scope/tree/main/docs/',
+            'https://github.com/Gusto/scope/tree/main/docs/',
         },
         theme: {
           customCss: './src/css/custom.css',
@@ -72,7 +72,7 @@ const config: Config = {
           label: 'Docs',
         },
         {
-          href: 'https://github.com/oscope-dev/scope',
+          href: 'https://github.com/Gusto/scope',
           label: 'GitHub',
           position: 'right',
         },
@@ -95,7 +95,7 @@ const config: Config = {
           items: [
             {
               label: 'GitHub',
-              href: 'https://github.com/oscope-dev/scope',
+              href: 'https://github.com/Gusto/scope',
             },
           ],
         },


### PR DESCRIPTION
## Summary
- Remove the tag glob trigger from `gh-page.yml` — it hasn't matched since the CalVer format changed in February
- Instead, call `gh-page.yml` directly from the Release workflow via `workflow_call`
- This makes the dependency explicit: a release always deploys Pages
- Update `docusaurus.config.ts` to point at `Gusto` org (was still referencing `oscope-dev`)
- Add CI workflow README with mermaid diagram and CLAUDE.md for maintenance

## Blocked: GitHub Pages domain issue

GitHub Pages is enabled for the repo, but the Gusto org has a custom domain (`docs.gusto.com`) configured for Pages. That means this repo's docs would be served at `docs.gusto.com/scope/`, which is a problem because `docs.gusto.com` is Gusto's **official public API documentation portal** for customers and partners. An internal dev tool's docs shouldn't live there.

### Options to resolve
1. **Set a repo-level custom domain** (e.g., `scope-docs.gusto.com`) — requires DNS work and org admin help
2. **Host docs outside GitHub Pages** (Netlify, Vercel, Cloudflare Pages) — avoids the org domain issue entirely
3. **Don't deploy Pages from this org** — keep docs in the repo, read on GitHub directly
4. **Ask an org admin** if there's a way to exclude a single repo from the org-level custom domain

### Context
- Pages hasn't deployed since January 2026, when the repo was transferred from `oscope-dev` to `Gusto`
- The old `oscope-dev` org had no custom domain, so Pages worked at `oscope-dev.github.io/scope/`
- The `Gusto/gists` repo (internal visibility) gets an anonymized URL, but public repos are forced through `docs.gusto.com`

## Why Pages was broken before the domain issue
The `Build Github Pages` workflow triggered on tags matching `'**[0-9]+.[0-9]+.[0-9]+*'`. Old tags like `v2026.1.12` matched. New tags like `v2026.4.8+1002` do not — the `+` breaks the glob.

## Test plan
- [x] Verified full release pipeline via `workflow_dispatch` — Pages build step succeeds
- [x] Verified deploy step correctly skips on non-main branches
- [x] GitHub Pages enabled for Gusto/scope
- [ ] **Resolve domain issue** before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)