### PR TITLE
fix: decouple telemetry from user-facing output display

### DIFF
--- a/src/analyze/cli.rs
+++ b/src/analyze/cli.rs
@@ -1,6 +1,6 @@
 use super::error::AnalyzeError;
 use crate::prelude::{
-    CaptureError, CaptureOpts, DefaultExecutionProvider, ExecutionProvider, OutputDestination,
+    CaptureError, CaptureOpts, DefaultExecutionProvider, ExecutionProvider, OutputDisplay,
 };
 use crate::shared::analyze;
 use crate::shared::prelude::FoundConfig;
@@ -84,7 +84,7 @@ async fn analyze_command(found_config: &FoundConfig, args: &AnalyzeCommandArgs) 
         env_vars: Default::default(),
         path: &path,
         args: &command,
-        output_dest: OutputDestination::StandardOutWithPrefix("analyzing".to_string()),
+        output_dest: OutputDisplay::VisibleWithPrefix("analyzing".to_string()),
     };
 
     let result = analyze::process_lines(

--- a/src/bin/scope-intercept.rs
+++ b/src/bin/scope-intercept.rs
@@ -70,7 +70,7 @@ async fn run_command(opts: Cli) -> anyhow::Result<i32> {
     let capture = OutputCapture::capture_output(CaptureOpts {
         working_dir: &current_dir,
         args: &command,
-        output_dest: OutputDestination::StandardOut,
+        output_dest: OutputDisplay::Visible,
         path: &path,
         env_vars: Default::default(),
     })

--- a/src/bin/scope.rs
+++ b/src/bin/scope.rs
@@ -129,7 +129,7 @@ async fn exec_sub_command(found_config: &FoundConfig, args: &[String]) -> Result
     let capture = OutputCapture::capture_output(CaptureOpts {
         working_dir: &found_config.working_dir,
         args: &args,
-        output_dest: OutputDestination::StandardOut,
+        output_dest: OutputDisplay::Visible,
         path: &found_config.bin_path,
         env_vars: BTreeMap::from([
             (

--- a/src/doctor/check.rs
+++ b/src/doctor/check.rs
@@ -14,7 +14,7 @@ use crate::prelude::{
 use crate::shared::analyze::{self, AnalyzeStatus};
 use crate::shared::prelude::{
     CaptureError, CaptureOpts, DoctorCommands, DoctorGroup, DoctorGroupAction,
-    DoctorGroupCachePath, ExecutionProvider, OutputDestination,
+    DoctorGroupCachePath, ExecutionProvider, OutputDisplay,
 };
 use async_trait::async_trait;
 use derive_builder::Builder;
@@ -511,7 +511,7 @@ impl DefaultDoctorActionRun {
             .run_command(CaptureOpts {
                 working_dir: &self.working_dir,
                 args: &args,
-                output_dest: OutputDestination::StandardOutWithPrefix(format!(
+                output_dest: OutputDisplay::VisibleWithPrefix(format!(
                     "{}/{}",
                     self.model.metadata.name(),
                     self.action.name
@@ -625,7 +625,7 @@ impl DefaultDoctorActionRun {
                 .run_command(CaptureOpts {
                     working_dir: &self.working_dir,
                     args: &args,
-                    output_dest: OutputDestination::Logging,
+                    output_dest: OutputDisplay::Silent,
                     path: &path,
                     env_vars: generate_env_vars(),
                 })

--- a/src/doctor/runner.rs
+++ b/src/doctor/runner.rs
@@ -2,10 +2,9 @@ use super::check::{ActionRunResult, ActionRunStatus, DoctorActionRun};
 use crate::doctor::check::RuntimeError;
 use crate::models::HelpMetadata;
 use crate::prelude::{
-    ActionReport, ActionTaskReport, CaptureOpts, ExecutionProvider, GroupReport, OutputDestination,
+    ActionReport, ActionTaskReport, CaptureOpts, ExecutionProvider, GroupReport, OutputDisplay,
     SkipSpec, generate_env_vars, progress_bar_without_pos,
 };
-use crate::report_stdout;
 use crate::shared::prelude::DoctorGroup;
 use anyhow::Result;
 use colored::Colorize;
@@ -161,7 +160,7 @@ where
                     .run_command(CaptureOpts {
                         working_dir: &self.exec_working_dir,
                         args: &args,
-                        output_dest: OutputDestination::Logging,
+                        output_dest: OutputDisplay::Silent,
                         path: &path,
                         env_vars: generate_env_vars(),
                     })
@@ -447,8 +446,14 @@ async fn print_pretty_result(
         if let Some(text) = task.output {
             let line_prefix = format!("{group_name}/{action_name}");
             for line in text.lines() {
-                let output_line = format!("{}:  {}", line_prefix.dimmed(), line);
-                report_stdout!("{}", output_line);
+                // Only write to stdout — tracing already happened during capture
+                writeln!(
+                    crate::prelude::STDOUT_WRITER.write().await,
+                    "{}:  {}\r",
+                    line_prefix.dimmed(),
+                    line
+                )
+                .ok();
             }
         }
     }
@@ -456,14 +461,16 @@ async fn print_pretty_result(
     Ok(())
 }
 
-/// Returns the action task reports for display based on the presumed action report status.
+/// Returns the most relevant action task reports for display.
+/// Priority: validate > fix > check — shows the latest phase that ran,
+/// which is the most useful output when diagnosing failures.
 fn action_task_reports_for_display(action_report: &ActionReport) -> Vec<ActionTaskReport> {
-    if !action_report.check.is_empty() {
-        action_report.check.clone()
+    if !action_report.validate.is_empty() {
+        action_report.validate.clone()
     } else if !action_report.fix.is_empty() {
         action_report.fix.clone()
     } else {
-        action_report.validate.clone()
+        action_report.check.clone()
     }
 }
 
@@ -943,7 +950,7 @@ mod tests {
     }
 
     #[test]
-    fn test_action_task_reports_for_display_when_check_nonempty() {
+    fn test_action_task_reports_for_display_prefers_validate_over_all() {
         let action_report = ActionReport {
             action_name: "test".to_string(),
             check: vec![ActionTaskReport {
@@ -962,22 +969,22 @@ mod tests {
 
         let task_reports = action_task_reports_for_display(&action_report);
         let actual = task_reports.first().unwrap();
-        assert_eq!(actual.output, Some("check output".to_string()));
+        assert_eq!(actual.output, Some("validate output".to_string()));
     }
 
     #[test]
-    fn test_action_task_reports_for_display_when_fix_nonempty() {
+    fn test_action_task_reports_for_display_prefers_fix_over_check() {
         let action_report = ActionReport {
             action_name: "test".to_string(),
-            check: vec![],
+            check: vec![ActionTaskReport {
+                output: Some("check output".to_string()),
+                ..Default::default()
+            }],
             fix: vec![ActionTaskReport {
                 output: Some("fix output".to_string()),
                 ..Default::default()
             }],
-            validate: vec![ActionTaskReport {
-                output: Some("validate output".to_string()),
-                ..Default::default()
-            }],
+            validate: vec![],
         };
 
         let task_reports = action_task_reports_for_display(&action_report);

--- a/src/report/cli.rs
+++ b/src/report/cli.rs
@@ -2,7 +2,7 @@ use crate::prelude::{
     DefaultExecutionProvider, DefaultUnstructuredReportBuilder, ReportRenderer,
     UnstructuredReportBuilder,
 };
-use crate::shared::prelude::{CaptureOpts, FoundConfig, OutputCapture, OutputDestination};
+use crate::shared::prelude::{CaptureOpts, FoundConfig, OutputCapture, OutputDisplay};
 use anyhow::Result;
 use clap::Args;
 use std::sync::Arc;
@@ -24,7 +24,7 @@ pub async fn report_root(found_config: &FoundConfig, args: &ReportArgs) -> Resul
     let capture = OutputCapture::capture_output(CaptureOpts {
         working_dir: &found_config.working_dir,
         args: &args.command,
-        output_dest: OutputDestination::Logging,
+        output_dest: OutputDisplay::Silent,
         path: &found_config.bin_path,
         env_vars: Default::default(),
     })

--- a/src/shared/analyze/mod.rs
+++ b/src/shared/analyze/mod.rs
@@ -1,7 +1,7 @@
 use crate::models::HelpMetadata;
 use crate::prelude::{
     CaptureOpts, DefaultExecutionProvider, DoctorFix, ExecutionProvider, KnownError, OutputCapture,
-    OutputDestination, generate_env_vars,
+    OutputDisplay, generate_env_vars,
 };
 use anyhow::Result;
 use inquire::InquireError;
@@ -142,7 +142,7 @@ async fn run_fix(
         let capture_opts = CaptureOpts {
             working_dir,
             args: &[cmd.text().to_string()],
-            output_dest: OutputDestination::StandardOutWithPrefix("fixing".to_string()),
+            output_dest: OutputDisplay::VisibleWithPrefix("fixing".to_string()),
             path: exec_path,
             env_vars: generate_env_vars(),
         };

--- a/src/shared/capture.rs
+++ b/src/shared/capture.rs
@@ -49,18 +49,17 @@ pub struct OutputCapture {
 }
 
 #[derive(Clone, Debug)]
-pub enum OutputDestination {
-    StandardOut,
-    StandardOutWithPrefix(String),
-    Logging,
-    Null,
+pub enum OutputDisplay {
+    Visible,
+    VisibleWithPrefix(String),
+    Silent,
 }
 
 struct StreamCapture<R: io::AsyncRead + Unpin> {
     reader: R,
     writer: Arc<RwLock<Box<dyn std::io::Write + Send + Sync>>>,
     level: Level,
-    dest: OutputDestination,
+    dest: OutputDisplay,
 }
 
 impl<R: io::AsyncRead + Unpin> StreamCapture<R> {
@@ -70,15 +69,19 @@ impl<R: io::AsyncRead + Unpin> StreamCapture<R> {
         let mut reader = BufReader::new(self.reader).lines();
         while let Some(line) = reader.next_line().await? {
             captured.add_line(&line).await;
+
+            // Always trace — telemetry is not optional
+            match self.level {
+                Level::ERROR => error!("{}", line),
+                _ => info!("{}", line),
+            }
+
+            // Optionally display to user
             match &self.dest {
-                OutputDestination::Logging => match self.level {
-                    Level::ERROR => error!("{}", line),
-                    _ => info!("{}", line),
-                },
-                OutputDestination::StandardOut => {
+                OutputDisplay::Visible => {
                     writeln!(self.writer.write().await, "{line}\r").ok();
                 }
-                OutputDestination::StandardOutWithPrefix(prefix) => {
+                OutputDisplay::VisibleWithPrefix(prefix) => {
                     writeln!(
                         self.writer.write().await,
                         "{}:  {}\r",
@@ -87,7 +90,7 @@ impl<R: io::AsyncRead + Unpin> StreamCapture<R> {
                     )
                     .ok();
                 }
-                OutputDestination::Null => {}
+                OutputDisplay::Silent => {}
             };
         }
 
@@ -122,7 +125,7 @@ pub trait ExecutionProvider: Send + Sync {
             .run_command(CaptureOpts {
                 working_dir: workdir,
                 args: &args,
-                output_dest: OutputDestination::Null,
+                output_dest: OutputDisplay::Silent,
                 path,
                 env_vars: Default::default(),
             })
@@ -150,7 +153,7 @@ pub struct CaptureOpts<'a> {
     pub env_vars: BTreeMap<String, String>,
     pub path: &'a str,
     pub args: &'a [String],
-    pub output_dest: OutputDestination,
+    pub output_dest: OutputDisplay,
 }
 
 impl<'a> CaptureOpts<'a> {

--- a/src/shared/logging.rs
+++ b/src/shared/logging.rs
@@ -243,8 +243,8 @@ impl LoggingOpts {
             .with_batch_exporter(span_exporter?)
             .with_sampler(Sampler::AlwaysOn)
             .with_id_generator(RandomIdGenerator::default())
-            .with_max_attributes_per_span(16)
-            .with_max_events_per_span(16)
+            .with_max_attributes_per_span(128)
+            .with_max_events_per_span(128)
             .with_resource(resource.clone())
             .build();
 

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -21,7 +21,7 @@ pub const RUN_ID_ENV_VAR: &str = "SCOPE_RUN_ID";
 pub mod prelude {
     pub use super::capture::{
         CaptureError, CaptureOpts, DefaultExecutionProvider, ExecutionProvider,
-        MockExecutionProvider, OutputCapture, OutputCaptureBuilder, OutputDestination,
+        MockExecutionProvider, OutputCapture, OutputCaptureBuilder, OutputDisplay,
     };
     pub use super::config_load::{ConfigOptions, FoundConfig, build_config_path};
     pub use super::logging::{LoggingOpts, STDERR_WRITER, STDOUT_WRITER, progress_bar_without_pos};


### PR DESCRIPTION
## Summary

- **Refactors `OutputDestination` → `OutputDisplay`**: The old enum conflated telemetry with terminal display as mutually exclusive choices. Fix commands used `StandardOutWithPrefix` (stdout only, no trace) and check commands used `Logging` (trace only, no stdout). The new `OutputDisplay` enum (`Visible`, `VisibleWithPrefix`, `Silent`) controls only what the user sees — the capture loop now always traces every line regardless of display mode.
- **Fixes `action_task_reports_for_display` priority**: Was check > fix > validate, now validate > fix > check. When a fix fails, the user sees the fix output instead of the earlier check output.
- **Increases `max_events_per_span` from 16 → 128**: Matches the SDK default and prevents trace event truncation for commands with many output lines.

## Context

Trace events from `scope doctor run` were missing in Datadog. The root cause was that `OutputDestination` treated telemetry and user display as mutually exclusive — fix command output was never traced, only written to stdout. This was validated against a large internal repository to confirm trace events now appear correctly.

## Files changed

| File | Change |
|------|--------|
| `src/shared/capture.rs` | Core: enum refactor + always-trace in capture loop |
| `src/doctor/runner.rs` | Fix replay path + fix display priority + update tests |
| `src/shared/logging.rs` | Increase span limits 16 → 128 |
| `src/doctor/check.rs` | Update 2 OutputDestination references |
| `src/report/cli.rs` | Update 1 reference |
| `src/analyze/cli.rs` | Update 1 reference |
| `src/shared/analyze/mod.rs` | Update 1 reference |
| `src/bin/scope.rs` | Update 1 reference |
| `src/bin/scope-intercept.rs` | Update 1 reference |
| `src/shared/mod.rs` | Update re-exports |

## Test plan

- [x] `cargo build` — compiles cleanly
- [x] `cargo test` — 165 tests pass (including updated `action_task_reports_for_display` tests)
- [x] Tested against a large internal repository — trace events now appear correctly in Datadog

<details>
<summary>Manual test steps (local Jaeger)</summary>

### Prerequisites

Start a local Jaeger instance with OTLP ingestion enabled on port 14317 (gRPC) and 14318 (HTTP), then build scope.

```bash
cargo build
```

Jaeger UI: http://localhost:16686

### Test 1: Fix command output appears in traces (the core bug)

```bash
cd tests/test-cases/simple-check-fix
rm -f file-mod.txt

SCOPE_OTEL_ENDPOINT=http://localhost:14317 \
SCOPE_OTEL_PROTOCOL=grpc \
SCOPE_OTEL_SERVICE=scope-manual-test \
../../../target/debug/scope doctor run --no-cache --fix true
```

**Verify in Jaeger**: Search for service `scope-manual-test`. The `capture_output` spans should contain trace events from the fix command. The `group path-exists` span should NOT have error status.

```bash
rm -f file-mod.txt
```

### Test 2: Failed fix output appears in traces

```bash
cd tests/test-cases/simple-check-fail

SCOPE_OTEL_ENDPOINT=http://localhost:14317 \
SCOPE_OTEL_PROTOCOL=grpc \
SCOPE_OTEL_SERVICE=scope-manual-test \
../../../target/debug/scope doctor run --no-cache --fix true
```

**Verify in Jaeger**: Trace should have error status. Check, fix, and verification output should all appear as trace events on separate `capture_output` spans. Terminal should show prefixed output (`path-exists/file-exists:`).

### Test 3: Check output still traced (regression check)

```bash
cd tests/test-cases/simple-check-fix
touch file-mod.txt

SCOPE_OTEL_ENDPOINT=http://localhost:14317 \
SCOPE_OTEL_PROTOCOL=grpc \
SCOPE_OTEL_SERVICE=scope-manual-test \
../../../target/debug/scope doctor run --no-cache

rm file-mod.txt
```

**Verify in Jaeger**: Trace should be successful. Check command output appears as trace events on `capture_output` spans.

### Test 4: Skip command output is traced

```bash
cd tests/test-cases/group-skip-command

SCOPE_OTEL_ENDPOINT=http://localhost:14317 \
SCOPE_OTEL_PROTOCOL=grpc \
SCOPE_OTEL_SERVICE=scope-manual-test \
../../../target/debug/scope doctor run --no-cache
```

**Verify in Jaeger**: Skip command execution has a `capture_output` span.

### Test 5: Multiple groups with mixed pass/fail

```bash
cd tests/test-cases/two-groups
rm -f file-mod.txt file-bar.txt

SCOPE_OTEL_ENDPOINT=http://localhost:14317 \
SCOPE_OTEL_PROTOCOL=grpc \
SCOPE_OTEL_SERVICE=scope-manual-test \
../../../target/debug/scope doctor run --no-cache --fix true

rm -f file-mod.txt file-bar.txt
```

**Verify in Jaeger**: Both group spans visible, each with their own `capture_output` children. Events are on the correct child spans.

### Test 6: Span limit increase (50 lines, was truncated at 16)

```bash
mkdir -p /tmp/scope-limit-test/.scope
cat > /tmp/scope-limit-test/.scope/verbose.yaml << 'YAML'
apiVersion: scope.github.com/v1alpha
kind: ScopeDoctorGroup
metadata:
  name: verbose-output
  description: Produces many lines of output
spec:
  actions:
    - name: many-lines
      check:
        commands:
          - "seq 1 50"
      fix:
        commands:
          - "seq 1 50"
YAML

cd /tmp/scope-limit-test

SCOPE_OTEL_ENDPOINT=http://localhost:14317 \
SCOPE_OTEL_PROTOCOL=grpc \
SCOPE_OTEL_SERVICE=scope-manual-test \
scope doctor run --no-cache --fix true

rm -rf /tmp/scope-limit-test
```

**Verify in Jaeger**: All 50 lines (1 through 50) appear as trace events on the `capture_output` span — none truncated.

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)