### PR TITLE
fix: restore OTLP HTTP telemetry broken by opentelemetry-otlp 0.31 feature conflict

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ normpath = "1.5.0"
 octocrab = "*"
 opentelemetry = { version = "*", features = ["metrics"] }
 opentelemetry_sdk = { version = "*", features = ["metrics", "rt-tokio", "experimental_metrics_periodicreader_with_async_runtime"] }
-opentelemetry-otlp = { version = "*", features = ["metrics", "reqwest", "http-proto", "reqwest-client", "reqwest-rustls", "grpc-tonic"] }
+opentelemetry-otlp = { version = "*", default-features = false, features = ["trace", "metrics", "internal-logs", "http-proto", "reqwest-blocking-client", "reqwest-rustls", "grpc-tonic"] }
 path-clean = "1.0.1"
 pathdiff = "0.2.3"
 petgraph = "0.8.3"

--- a/src/shared/capture.rs
+++ b/src/shared/capture.rs
@@ -244,7 +244,7 @@ impl OutputCapture {
         output.extend(stdout);
         output.extend(stderr);
 
-        output.sort_by(|(l_time, _), (r_time, _)| l_time.cmp(r_time));
+        output.sort_by_key(|(l_time, _)| *l_time);
 
         let text: String = output
             .iter()
@@ -260,7 +260,7 @@ impl OutputCapture {
         output.extend(self.stdout.iter());
         output.extend(self.stderr.iter());
 
-        output.sort_by(|(l_time, _), (r_time, _)| l_time.cmp(r_time));
+        output.sort_by_key(|(l_time, _)| *l_time);
 
         output
             .iter()

--- a/src/shared/logging.rs
+++ b/src/shared/logging.rs
@@ -416,3 +416,29 @@ impl LoggingOpts {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn http_span_exporter_builds_with_default_client() {
+        let url = Url::parse("http://127.0.0.1:4318/v1/traces").unwrap();
+        let result = SpanExporter::builder()
+            .with_http()
+            .with_endpoint(url)
+            .with_timeout(Duration::from_secs(3))
+            .build();
+        assert!(result.is_ok(), "HTTP span exporter must build; got {:?}", result.err());
+    }
+
+    #[test]
+    fn http_metric_exporter_builds_with_default_client() {
+        let result = MetricExporter::builder()
+            .with_http()
+            .with_endpoint("http://127.0.0.1:4318")
+            .with_timeout(Duration::from_secs(3))
+            .build();
+        assert!(result.is_ok(), "HTTP metric exporter must build; got {:?}", result.err());
+    }
+}

--- a/src/shared/logging.rs
+++ b/src/shared/logging.rs
@@ -429,7 +429,11 @@ mod tests {
             .with_endpoint(url)
             .with_timeout(Duration::from_secs(3))
             .build();
-        assert!(result.is_ok(), "HTTP span exporter must build; got {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "HTTP span exporter must build; got {:?}",
+            result.err()
+        );
     }
 
     #[test]
@@ -439,6 +443,10 @@ mod tests {
             .with_endpoint("http://127.0.0.1:4318")
             .with_timeout(Duration::from_secs(3))
             .build();
-        assert!(result.is_ok(), "HTTP metric exporter must build; got {:?}", result.err());
+        assert!(
+            result.is_ok(),
+            "HTTP metric exporter must build; got {:?}",
+            result.err()
+        );
     }
 }


### PR DESCRIPTION
## Problem

After the opentelemetry-otlp 0.27 → 0.31 upgrade (#251), any deployment using `SCOPE_OTEL_PROTOCOL=http` silently stopped sending traces and metrics. The runtime error:

```
opentelemetry configuration failed. Events will not be sent. no http client specified
```

The CLI continues running normally with telemetry disabled, so the failure is invisible to users.

## Root cause

opentelemetry-otlp 0.31 changed how the default HTTP client is selected ([source](https://github.com/open-telemetry/opentelemetry-rust/blob/opentelemetry-otlp-0.31.1/opentelemetry-otlp/src/exporter/http/mod.rs#L151-L195)). A client is only auto-installed when **exactly one** of `hyper-client`, `reqwest-client`, or `reqwest-blocking-client` is enabled. The async-reqwest auto-default has this cfg gate:

```rust
all(not(feature = "hyper-client"), not(feature = "reqwest-blocking-client"), feature = "reqwest-client")
```

Our `Cargo.toml` explicitly enabled `reqwest-client` but did not set `default-features = false`. The crate's own defaults include `reqwest-blocking-client` ([Cargo.toml:69](https://github.com/open-telemetry/opentelemetry-rust/blob/opentelemetry-otlp-0.31.1/opentelemetry-otlp/Cargo.toml)). With both features active, the cfg never matched, `http_config.client` stayed `None`, and `.build()` returned `ExporterBuildError::NoHttpClient`.

This was silent in 0.27 because `HttpConfig::default()` always provided a blocking client unconditionally regardless of feature flags.

## Fix

- Set `default-features = false` on `opentelemetry-otlp`
- Switch from `reqwest-client` (async) to `reqwest-blocking-client` (blocking) — correct for this use case since the OTLP `BatchProcessor` runs in a plain `std::thread`, not a tokio task. The async client caused a secondary panic ("there is no reactor running") when the batch thread tried to flush on shutdown.
- Re-add `trace` and `internal-logs` to the explicit feature list (previously supplied by the now-disabled defaults)

## Testing

- Confirmed the error reproduces on `main` before this fix
- After fix: no error, traces confirmed arriving in Jaeger via OTLP HTTP
- Two regression tests added that assert `SpanExporter` and `MetricExporter` HTTP builders return `Ok` — both fail on pre-fix code with `NoHttpClient` and pass after

## Checklist

- [x] `cargo test` passes
- [x] End-to-end verified: traces visible in Jaeger
- [x] Regression tests added
