### PR TITLE
fix(release): build x86_64-unknown-linux-gnu natively instead of with cross

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
             use-cross: false
           - target: x86_64-unknown-linux-gnu
             runner: ubuntu-latest
-            use-cross: true
+            use-cross: false
           - target: x86_64-unknown-linux-musl
             runner: ubuntu-latest
             use-cross: true


### PR DESCRIPTION
## Summary

- The Release workflow has been failing on the `x86_64-unknown-linux-gnu` target since the opentelemetry 0.32 stack was bumped (that bump brought `rustls` 0.23 → `aws-lc-rs` → `aws-lc-sys` into the dep tree).
- `aws-lc-sys`'s build script panics when it detects a GCC memcmp bug (gcc.gnu.org/bugzilla/95189, fixed in GCC 10.4). The `ghcr.io/cross-rs/x86_64-unknown-linux-gnu:main` Docker image ships GCC < 10.4, so the check always trips.
- The other three targets (`aarch64-apple-darwin`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`) all passed because they use different images or don't hit this code path.
- `x86_64-unknown-linux-gnu` is the **native target** on the `ubuntu-latest` runner — we don't need `cross` at all for it. Switching to `use-cross: false` builds it with plain `cargo`, which uses the host GCC (Ubuntu 24.04 ships GCC 13) and sidesteps the issue entirely.

## Test plan

- [ ] Confirm the Release workflow passes all four build targets after merge
- [ ] Verify the `x86_64-unknown-linux-gnu` artifact is produced correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)