### PR TITLE
feat(known-error): support multiple regex patterns per known error

### DIFF
--- a/examples/v1alpha/KnownErrorMultiPattern.yaml
+++ b/examples/v1alpha/KnownErrorMultiPattern.yaml
@@ -1,0 +1,10 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: disk-full-or-oom
+  description: Check if the output contains a disk-full or out-of-memory error
+spec:
+  pattern:
+    - "No space left on device"
+    - "Out of memory"
+  help: "The system ran out of disk space or memory. Free up resources and try again."

--- a/schema/merged.json
+++ b/schema/merged.json
@@ -216,6 +216,22 @@
         "ScopeKnownError"
       ]
     },
+    "KnownErrorPattern": {
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "anyOf": [
+        {
+          "description": "A single regex pattern.",
+          "type": "string"
+        },
+        {
+          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "KnownErrorSpec": {
       "description": "Definition of the known error",
       "type": "object",
@@ -236,8 +252,8 @@
           "type": "string"
         },
         "pattern": {
-          "description": "A Regex used to determine if the line is an error.",
-          "type": "string"
+          "description": "A regex (or list of regexes) used to determine if the line is an error.\nA single string or a list of strings are both accepted; the known error fires when any\npattern matches.",
+          "$ref": "#/$defs/KnownErrorPattern"
         }
       },
       "additionalProperties": false,

--- a/schema/merged.json
+++ b/schema/merged.json
@@ -224,11 +224,12 @@
           "type": "string"
         },
         {
-          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "description": "A list of regex patterns (at least one); the known error fires when any one matches.",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     },

--- a/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -232,6 +232,22 @@
         "ScopeKnownError"
       ]
     },
+    "KnownErrorPattern": {
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "anyOf": [
+        {
+          "description": "A single regex pattern.",
+          "type": "string"
+        },
+        {
+          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "KnownErrorSpec": {
       "description": "Definition of the known error",
       "type": "object",
@@ -252,8 +268,8 @@
           "type": "string"
         },
         "pattern": {
-          "description": "A Regex used to determine if the line is an error.",
-          "type": "string"
+          "description": "A regex (or list of regexes) used to determine if the line is an error.\nA single string or a list of strings are both accepted; the known error fires when any\npattern matches.",
+          "$ref": "#/$defs/KnownErrorPattern"
         }
       },
       "additionalProperties": false,

--- a/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -240,11 +240,12 @@
           "type": "string"
         },
         {
-          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "description": "A list of regex patterns (at least one); the known error fires when any one matches.",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     },

--- a/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -232,6 +232,22 @@
         "ScopeKnownError"
       ]
     },
+    "KnownErrorPattern": {
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "anyOf": [
+        {
+          "description": "A single regex pattern.",
+          "type": "string"
+        },
+        {
+          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "KnownErrorSpec": {
       "description": "Definition of the known error",
       "type": "object",
@@ -252,8 +268,8 @@
           "type": "string"
         },
         "pattern": {
-          "description": "A Regex used to determine if the line is an error.",
-          "type": "string"
+          "description": "A regex (or list of regexes) used to determine if the line is an error.\nA single string or a list of strings are both accepted; the known error fires when any\npattern matches.",
+          "$ref": "#/$defs/KnownErrorPattern"
         }
       },
       "additionalProperties": false,

--- a/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -240,11 +240,12 @@
           "type": "string"
         },
         {
-          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "description": "A list of regex patterns (at least one); the known error fires when any one matches.",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     },

--- a/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -232,6 +232,22 @@
         "ScopeKnownError"
       ]
     },
+    "KnownErrorPattern": {
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "anyOf": [
+        {
+          "description": "A single regex pattern.",
+          "type": "string"
+        },
+        {
+          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      ]
+    },
     "KnownErrorSpec": {
       "description": "Definition of the known error",
       "type": "object",
@@ -252,8 +268,8 @@
           "type": "string"
         },
         "pattern": {
-          "description": "A Regex used to determine if the line is an error.",
-          "type": "string"
+          "description": "A regex (or list of regexes) used to determine if the line is an error.\nA single string or a list of strings are both accepted; the known error fires when any\npattern matches.",
+          "$ref": "#/$defs/KnownErrorPattern"
         }
       },
       "additionalProperties": false,

--- a/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -240,11 +240,12 @@
           "type": "string"
         },
         {
-          "description": "A list of regex patterns; the known error fires when any one matches.",
+          "description": "A list of regex patterns (at least one); the known error fires when any one matches.",
           "type": "array",
           "items": {
             "type": "string"
-          }
+          },
+          "minItems": 1
         }
       ]
     },

--- a/src/doctor/check.rs
+++ b/src/doctor/check.rs
@@ -1601,8 +1601,8 @@ pub(crate) mod tests {
                     },
                     labels: BTreeMap::new(),
                 },
-                pattern: pattern.to_string(),
-                regex: Regex::new(pattern).unwrap(),
+                patterns: vec![pattern.to_string()],
+                regexes: vec![Regex::new(pattern).unwrap()],
                 help_text: "test help".to_string(),
                 fix,
             }

--- a/src/doctor/check.rs
+++ b/src/doctor/check.rs
@@ -1573,7 +1573,7 @@ pub(crate) mod tests {
         use super::*;
         use crate::models::prelude::{ModelMetadata, ModelMetadataAnnotations};
         use crate::shared::analyze::AnalyzeStatus;
-        use regex::Regex;
+        use regex::RegexSet;
 
         fn make_known_error(pattern: &str, with_fix: bool) -> KnownError {
             let fix = if with_fix {
@@ -1601,8 +1601,7 @@ pub(crate) mod tests {
                     },
                     labels: BTreeMap::new(),
                 },
-                patterns: vec![pattern.to_string()],
-                regexes: vec![Regex::new(pattern).unwrap()],
+                regexes: RegexSet::new([pattern]).unwrap(),
                 help_text: "test help".to_string(),
                 fix,
             }

--- a/src/models/v1alpha/known_error.rs
+++ b/src/models/v1alpha/known_error.rs
@@ -7,6 +7,28 @@ use serde::{Deserialize, Serialize};
 
 use super::prelude::DoctorFixSpec;
 
+/// One or more regexes that determine whether a log line matches this known error.
+/// Accepts either a single pattern string or a list of pattern strings; a line matching
+/// any one of the patterns triggers the error.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[serde(untagged)]
+pub enum KnownErrorPattern {
+    /// A single regex pattern.
+    Single(String),
+    /// A list of regex patterns; the known error fires when any one matches.
+    Many(Vec<String>),
+}
+
+impl KnownErrorPattern {
+    /// Returns the list of pattern strings (a single value becomes a one-element vec).
+    pub fn patterns(&self) -> Vec<String> {
+        match self {
+            KnownErrorPattern::Single(p) => vec![p.clone()],
+            KnownErrorPattern::Many(p) => p.clone(),
+        }
+    }
+}
+
 /// Definition of the known error
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
@@ -15,8 +37,10 @@ pub struct KnownErrorSpec {
     /// Text that the user can use to fix the issue
     pub help: String,
 
-    /// A Regex used to determine if the line is an error.
-    pub pattern: String,
+    /// A regex (or list of regexes) used to determine if the line is an error.
+    /// A single string or a list of strings are both accepted; the known error fires when any
+    /// pattern matches.
+    pub pattern: KnownErrorPattern,
 
     /// An optional fix the user will be prompted to run.
     pub fix: Option<DoctorFixSpec>,
@@ -82,6 +106,9 @@ impl InternalScopeModel<KnownErrorSpec, V1AlphaKnownError> for V1AlphaKnownError
 
     #[cfg(test)]
     fn examples() -> Vec<String> {
-        vec!["v1alpha/KnownError.yaml".to_string()]
+        vec![
+            "v1alpha/KnownError.yaml".to_string(),
+            "v1alpha/KnownErrorMultiPattern.yaml".to_string(),
+        ]
     }
 }

--- a/src/models/v1alpha/known_error.rs
+++ b/src/models/v1alpha/known_error.rs
@@ -7,6 +7,18 @@ use serde::{Deserialize, Serialize};
 
 use super::prelude::DoctorFixSpec;
 
+/// Schema helper: the list variant must have at least one element.
+/// Using `schema_with` (rather than `#[schemars(length(min = 1))]`) avoids a stray
+/// `minLength: 1` keyword that `length` emits unconditionally alongside `minItems`.
+fn non_empty_string_list(generator: &mut schemars::generate::SchemaGenerator) -> schemars::Schema {
+    let item = generator.subschema_for::<String>();
+    schemars::json_schema!({
+        "type": "array",
+        "items": item,
+        "minItems": 1_u64
+    })
+}
+
 /// One or more regexes that determine whether a log line matches this known error.
 /// Accepts either a single pattern string or a list of pattern strings; a line matching
 /// any one of the patterns triggers the error.
@@ -15,8 +27,8 @@ use super::prelude::DoctorFixSpec;
 pub enum KnownErrorPattern {
     /// A single regex pattern.
     Single(String),
-    /// A list of regex patterns; the known error fires when any one matches.
-    Many(Vec<String>),
+    /// A list of regex patterns (at least one); the known error fires when any one matches.
+    Many(#[schemars(schema_with = "non_empty_string_list")] Vec<String>),
 }
 
 impl KnownErrorPattern {
@@ -110,5 +122,31 @@ impl InternalScopeModel<KnownErrorSpec, V1AlphaKnownError> for V1AlphaKnownError
             "v1alpha/KnownError.yaml".to_string(),
             "v1alpha/KnownErrorMultiPattern.yaml".to_string(),
         ]
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::InternalScopeModel;
+
+    #[test]
+    fn schema_rejects_empty_pattern_list() {
+        let value = serde_json::json!({
+            "apiVersion": "scope.github.com/v1alpha",
+            "kind": "ScopeKnownError",
+            "metadata": {
+                "name": "test",
+                "description": "test"
+            },
+            "spec": {
+                "pattern": [],
+                "help": "some help"
+            }
+        });
+        assert!(
+            V1AlphaKnownError::validate_resource(&value).is_err(),
+            "schema should reject an empty pattern list"
+        );
     }
 }

--- a/src/shared/analyze/mod.rs
+++ b/src/shared/analyze/mod.rs
@@ -34,7 +34,7 @@ where
         let mut known_errors_to_remove = Vec::new();
         for (name, ke) in &known_errors {
             debug!("Checking known error {}", ke.name());
-            if ke.regex.is_match(&line) {
+            if ke.regexes.iter().any(|r| r.is_match(&line)) {
                 warn!(target: "always", "Known error '{}' found on line {}", ke.name(), line_number);
                 info!(target: "always", "\t==> {}", ke.help_text);
 

--- a/src/shared/analyze/mod.rs
+++ b/src/shared/analyze/mod.rs
@@ -34,7 +34,7 @@ where
         let mut known_errors_to_remove = Vec::new();
         for (name, ke) in &known_errors {
             debug!("Checking known error {}", ke.name());
-            if ke.regexes.iter().any(|r| r.is_match(&line)) {
+            if ke.regexes.is_match(&line) {
                 warn!(target: "always", "Known error '{}' found on line {}", ke.name(), line_number);
                 info!(target: "always", "\t==> {}", ke.help_text);
 

--- a/src/shared/config_load.rs
+++ b/src/shared/config_load.rs
@@ -368,15 +368,15 @@ mod tests {
         let canonical_nested = fs::canonicalize(&nested_dir).unwrap();
 
         // Should include .scope directories for all ancestors
-        let expected_paths = vec![
+        let expected_paths = [
             canonical_nested.join(".scope"),
-            canonical_nested.parent().unwrap().join(".scope"), // child
+            canonical_nested.parent().unwrap().join(".scope"),
             canonical_nested
                 .parent()
                 .unwrap()
                 .parent()
                 .unwrap()
-                .join(".scope"), // parent
+                .join(".scope"),
             canonical_nested
                 .parent()
                 .unwrap()
@@ -384,7 +384,7 @@ mod tests {
                 .unwrap()
                 .parent()
                 .unwrap()
-                .join(".scope"), // temp_dir
+                .join(".scope"),
         ];
 
         // Check that all expected ancestor paths are present (in order)

--- a/src/shared/models/internal/known_error.rs
+++ b/src/shared/models/internal/known_error.rs
@@ -1,9 +1,9 @@
 use std::path::Path;
 
-use crate::models::prelude::{ModelMetadata, V1AlphaKnownError};
 use crate::models::HelpMetadata;
+use crate::models::prelude::{ModelMetadata, V1AlphaKnownError};
 use derivative::Derivative;
-use regex::Regex;
+use regex::RegexSet;
 
 use super::fix::DoctorFix;
 
@@ -13,11 +13,17 @@ use super::fix::DoctorFix;
 pub struct KnownError {
     pub full_name: String,
     pub metadata: ModelMetadata,
-    pub patterns: Vec<String>,
     #[derivative(PartialEq = "ignore")]
-    pub regexes: Vec<Regex>,
+    pub regexes: RegexSet,
     pub help_text: String,
     pub fix: Option<DoctorFix>,
+}
+
+impl KnownError {
+    /// Returns the original pattern strings in the order they were defined.
+    pub fn patterns(&self) -> &[String] {
+        self.regexes.patterns()
+    }
 }
 
 impl HelpMetadata for KnownError {
@@ -41,10 +47,8 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
                 value.full_name()
             );
         }
-        let regexes = patterns
-            .iter()
-            .map(|p| Regex::new(p))
-            .collect::<Result<Vec<_>, _>>()?;
+        // RegexSet::new accepts empty iterators, so the guard above is required.
+        let regexes = RegexSet::new(&patterns)?;
 
         let binding = value.metadata.containing_dir();
         let containing_dir = Path::new(&binding);
@@ -68,7 +72,6 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
         Ok(KnownError {
             full_name: value.full_name(),
             metadata: value.metadata,
-            patterns,
             regexes,
             help_text: value.spec.help,
             fix: maybe_fix,
@@ -131,7 +134,7 @@ spec:
             "The command had an error, try reading the logs around there to find out what happened.",
             model.help_text
         );
-        assert_eq!(vec!["error".to_string()], model.patterns);
+        assert_eq!(["error"], model.patterns());
     }
 
     #[test]
@@ -153,10 +156,7 @@ spec:
         let model = configs[0].get_known_error_spec().unwrap();
 
         assert_eq!("multi-error", model.metadata.name);
-        assert_eq!(
-            vec!["first error".to_string(), "second error".to_string()],
-            model.patterns
-        );
+        assert_eq!(["first error", "second error"], model.patterns());
         assert_eq!(2, model.regexes.len());
     }
 
@@ -211,12 +211,13 @@ spec:
 
         let actual = KnownError::try_from(input.clone()).unwrap();
 
+        // regexes is PartialEq-ignored; check patterns explicitly.
+        assert_eq!(["some regex pattern"], actual.patterns());
         assert_eq!(
             KnownError {
                 full_name: "ScopeKnownError/some test error".to_string(),
                 metadata: input.metadata,
-                patterns: vec!["some regex pattern".to_string()],
-                regexes: vec![Regex::new("some regex pattern").unwrap()],
+                regexes: RegexSet::new(["some regex pattern"]).unwrap(),
                 help_text: input.spec.help,
                 fix: Some(
                     DoctorFix::from_spec(
@@ -256,13 +257,10 @@ spec:
 
         let actual = KnownError::try_from(input).unwrap();
 
-        assert_eq!(
-            vec!["alpha error".to_string(), "beta error".to_string()],
-            actual.patterns
-        );
+        assert_eq!(["alpha error", "beta error"], actual.patterns());
         assert_eq!(2, actual.regexes.len());
-        assert!(actual.regexes[0].is_match("alpha error in output"));
-        assert!(actual.regexes[1].is_match("beta error in output"));
-        assert!(!actual.regexes[0].is_match("unrelated line"));
+        assert!(actual.regexes.is_match("alpha error in output"));
+        assert!(actual.regexes.is_match("beta error in output"));
+        assert!(!actual.regexes.is_match("unrelated line"));
     }
 }

--- a/src/shared/models/internal/known_error.rs
+++ b/src/shared/models/internal/known_error.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
-use crate::models::HelpMetadata;
 use crate::models::prelude::{ModelMetadata, V1AlphaKnownError};
+use crate::models::HelpMetadata;
 use derivative::Derivative;
 use regex::Regex;
 
@@ -13,9 +13,9 @@ use super::fix::DoctorFix;
 pub struct KnownError {
     pub full_name: String,
     pub metadata: ModelMetadata,
-    pub pattern: String,
+    pub patterns: Vec<String>,
     #[derivative(PartialEq = "ignore")]
-    pub regex: Regex,
+    pub regexes: Vec<Regex>,
     pub help_text: String,
     pub fix: Option<DoctorFix>,
 }
@@ -34,7 +34,17 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
     type Error = anyhow::Error;
 
     fn try_from(value: V1AlphaKnownError) -> Result<Self, Self::Error> {
-        let regex = Regex::new(&value.spec.pattern)?;
+        let patterns = value.spec.pattern.patterns();
+        if patterns.is_empty() {
+            anyhow::bail!(
+                "known error '{}' must have at least one pattern",
+                value.full_name()
+            );
+        }
+        let regexes = patterns
+            .iter()
+            .map(|p| Regex::new(p))
+            .collect::<Result<Vec<_>, _>>()?;
 
         let binding = value.metadata.containing_dir();
         let containing_dir = Path::new(&binding);
@@ -58,8 +68,8 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
         Ok(KnownError {
             full_name: value.full_name(),
             metadata: value.metadata,
-            pattern: value.spec.pattern,
-            regex,
+            patterns,
+            regexes,
             help_text: value.spec.help,
             fix: maybe_fix,
         })
@@ -70,16 +80,36 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
 mod tests {
     use super::*;
     use crate::prelude::{
-        DoctorFixSpec, KnownErrorKind, KnownErrorSpec, ModelMetadataAnnotations, V1AlphaApiVersion,
-        V1AlphaKnownError,
+        DoctorFixSpec, KnownErrorKind, KnownErrorPattern, KnownErrorSpec, ModelMetadataAnnotations,
+        V1AlphaApiVersion, V1AlphaKnownError,
     };
     use crate::shared::models::parse_models_from_string;
 
     use std::collections::BTreeMap;
     use std::path::Path;
 
+    fn make_metadata(
+        name: &str,
+        file_path: &str,
+        file_dir: &str,
+        working_dir: &str,
+    ) -> ModelMetadata {
+        ModelMetadata {
+            name: name.to_string(),
+            description: "some description".to_string(),
+            annotations: ModelMetadataAnnotations {
+                file_path: Some(file_path.to_string()),
+                file_dir: Some(file_dir.to_string()),
+                working_dir: Some(working_dir.to_string()),
+                bin_path: None,
+                extra: BTreeMap::new(),
+            },
+            labels: BTreeMap::new(),
+        }
+    }
+
     #[test]
-    fn test_parse_scope_known_error() {
+    fn parses_single_pattern_string() {
         let text = "apiVersion: scope.github.com/v1alpha
 kind: ScopeKnownError
 metadata:
@@ -101,23 +131,67 @@ spec:
             "The command had an error, try reading the logs around there to find out what happened.",
             model.help_text
         );
-        assert_eq!("error", model.pattern);
+        assert_eq!(vec!["error".to_string()], model.patterns);
     }
 
     #[test]
-    fn try_from_spec() {
-        let model_metadata = ModelMetadata {
-            name: "some test error".to_string(),
-            description: "some description".to_string(),
-            annotations: ModelMetadataAnnotations {
-                file_path: Some("/foo/bar/file.yaml".to_string()),
-                file_dir: Some("/foo/bar".to_string()),
-                working_dir: Some("/some/work/dir".to_string()),
-                bin_path: None,
-                extra: BTreeMap::new(),
+    fn parses_list_of_patterns() {
+        let text = "apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: multi-error
+spec:
+  pattern:
+    - first error
+    - second error
+  help: Multiple patterns matched.";
+
+        let path = Path::new("/foo/bar/file.yaml");
+        let work_dir = Path::new("/foo/bar");
+        let configs = parse_models_from_string(work_dir, path, text).unwrap();
+        assert_eq!(1, configs.len());
+        let model = configs[0].get_known_error_spec().unwrap();
+
+        assert_eq!("multi-error", model.metadata.name);
+        assert_eq!(
+            vec!["first error".to_string(), "second error".to_string()],
+            model.patterns
+        );
+        assert_eq!(2, model.regexes.len());
+    }
+
+    #[test]
+    fn empty_pattern_list_is_rejected() {
+        let metadata = make_metadata("bad-error", "/foo/bar/file.yaml", "/foo/bar", "/foo/bar");
+
+        let input = V1AlphaKnownError {
+            api_version: V1AlphaApiVersion::ScopeV1Alpha,
+            kind: KnownErrorKind::ScopeKnownError,
+            metadata,
+            spec: KnownErrorSpec {
+                help: "some help".to_string(),
+                pattern: KnownErrorPattern::Many(vec![]),
+                fix: None,
             },
-            labels: BTreeMap::new(),
         };
+
+        let result = KnownError::try_from(input);
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(
+            msg.contains("at least one pattern"),
+            "unexpected error: {msg}"
+        );
+    }
+
+    #[test]
+    fn try_from_single_pattern_spec() {
+        let model_metadata = make_metadata(
+            "some test error",
+            "/foo/bar/file.yaml",
+            "/foo/bar",
+            "/some/work/dir",
+        );
 
         let input = V1AlphaKnownError {
             api_version: V1AlphaApiVersion::ScopeV1Alpha,
@@ -125,7 +199,7 @@ spec:
             metadata: model_metadata.clone(),
             spec: KnownErrorSpec {
                 help: "some help text".to_string(),
-                pattern: "some regex pattern".to_string(),
+                pattern: KnownErrorPattern::Single("some regex pattern".to_string()),
                 fix: Some(DoctorFixSpec {
                     commands: vec!["echo 'fix it!'".to_string()],
                     help_text: None,
@@ -141,8 +215,8 @@ spec:
             KnownError {
                 full_name: "ScopeKnownError/some test error".to_string(),
                 metadata: input.metadata,
-                pattern: input.spec.pattern.clone(),
-                regex: Regex::new(&input.spec.pattern).unwrap(),
+                patterns: vec!["some regex pattern".to_string()],
+                regexes: vec![Regex::new("some regex pattern").unwrap()],
                 help_text: input.spec.help,
                 fix: Some(
                     DoctorFix::from_spec(
@@ -155,5 +229,40 @@ spec:
             },
             actual
         )
+    }
+
+    #[test]
+    fn try_from_multi_pattern_spec() {
+        let model_metadata = make_metadata(
+            "multi-error",
+            "/foo/bar/file.yaml",
+            "/foo/bar",
+            "/some/work/dir",
+        );
+
+        let input = V1AlphaKnownError {
+            api_version: V1AlphaApiVersion::ScopeV1Alpha,
+            kind: KnownErrorKind::ScopeKnownError,
+            metadata: model_metadata.clone(),
+            spec: KnownErrorSpec {
+                help: "some help text".to_string(),
+                pattern: KnownErrorPattern::Many(vec![
+                    "alpha error".to_string(),
+                    "beta error".to_string(),
+                ]),
+                fix: None,
+            },
+        };
+
+        let actual = KnownError::try_from(input).unwrap();
+
+        assert_eq!(
+            vec!["alpha error".to_string(), "beta error".to_string()],
+            actual.patterns
+        );
+        assert_eq!(2, actual.regexes.len());
+        assert!(actual.regexes[0].is_match("alpha error in output"));
+        assert!(actual.regexes[1].is_match("beta error in output"));
+        assert!(!actual.regexes[0].is_match("unrelated line"));
     }
 }


### PR DESCRIPTION
## Summary

- `spec.pattern` now accepts either a single string (existing behavior, unchanged) or a list of strings
- A log line matching **any one** of the patterns triggers the known error
- An empty list is rejected at both the schema layer and at parse time
- Internally, patterns are compiled into a `RegexSet` for single-pass matching

## Details

Uses a `#[serde(untagged)]` enum (`KnownErrorPattern`) to accept both forms under the same `pattern` key — the same idiom already used by `SkipSpec` in this codebase. Single-string configs round-trip unchanged; no migration needed.

```yaml
# still works
spec:
  pattern: "No space left on device"

# now also works
spec:
  pattern:
    - "No space left on device"
    - "Out of memory"
```

### Implementation notes

- **Schema**: the `Many` variant carries `minItems: 1` via a `schema_with` helper, so schema-aware tooling (IDE validators, YAML linters) catches `pattern: []` at authoring time. A runtime guard in `TryFrom` remains as defense-in-depth since `validate_resource` only warns on schema mismatches.
- **Internal model**: the old parallel `patterns: Vec<String>` / `regexes: Vec<Regex>` fields are replaced by a single `regexes: RegexSet`. `RegexSet` matches all patterns in one DFA pass and exposes the original strings via `.patterns()`, eliminating the dual-storage issue.
- Also includes a pre-existing clippy lint fix (`useless_vec` → array literal in a test) that would otherwise fail CI under `-D warnings`.

## Test plan

- [x] `cargo test` — all existing tests pass (backward compatibility)
- [x] New unit tests: `parses_list_of_patterns`, `empty_pattern_list_is_rejected`, `try_from_multi_pattern_spec`
- [x] `schema_rejects_empty_pattern_list` — confirms `pattern: []` is caught at the schema layer
- [x] `cargo test create_and_validate_schemas` — regenerated schemas validated against both single-string and multi-pattern example fixtures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)