### PR TITLE
Run every check under --fix=false and warn on unrun fixes

### DIFF
--- a/src/doctor/check.rs
+++ b/src/doctor/check.rs
@@ -1067,6 +1067,26 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
+    async fn test_fix_false_check_fails_reports_no_run_fix_without_running_fix() -> Result<()> {
+        let action = build_run_fail_fix_succeed_action();
+        let mut exec_runner = MockExecutionProvider::new();
+        let glob_walker = MockGlobWalker::new();
+
+        command_result(&mut exec_runner, "check", vec![1]);
+
+        let mut run = setup_test(vec![action], exec_runner, glob_walker);
+        run.run_fix = false;
+
+        let result = run.run_action(panic_if_user_is_prompted).await?;
+        assert_eq!(ActionRunStatus::CheckFailedNoRunFix, result.status);
+
+        assert!(result.action_report.check.len() == 1);
+        assert!(result.action_report.fix.is_empty());
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_file_cache_invalid_fix_works() -> Result<()> {
         let action = build_file_fix_action();
         let mut glob_walker = MockGlobWalker::new();

--- a/src/doctor/runner.rs
+++ b/src/doctor/runner.rs
@@ -78,11 +78,20 @@ impl PathRunResult {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 enum GroupExecutionStatus {
     Succeeded,
-    Failed,
     Skipped,
+    Failed,
+}
+
+impl GroupExecutionStatus {
+    /// Combine with a newly observed action status, keeping whichever is more
+    /// severe. Ensures a later successful action can't clear an earlier
+    /// failure/skip within the same group.
+    fn merge(self, other: Self) -> Self {
+        std::cmp::max(self, other)
+    }
 }
 
 #[derive(Debug)]
@@ -324,7 +333,7 @@ where
                 .await
                 .ok();
 
-            results.status = match action_result.status {
+            let action_status = match action_result.status {
                 ActionRunStatus::CheckSucceeded
                 | ActionRunStatus::NoCheckFixSucceeded
                 | ActionRunStatus::CheckFailedFixSucceedVerifySucceed => {
@@ -333,13 +342,26 @@ where
                 ActionRunStatus::CheckFailedFixUserDenied => GroupExecutionStatus::Skipped,
                 _ => GroupExecutionStatus::Failed,
             };
+            // Merge (worst-wins) rather than overwrite, so a later succeeding
+            // action can't clear an earlier failure/skip in the same group.
+            results.status = results.status.merge(action_status);
 
+            // Derived from `action_status` (rather than re-matching on
+            // `action_result.status`) so a newly added `ActionRunStatus` variant
+            // only needs classifying once, above, to affect both group status and
+            // halting — the two decisions can't silently diverge. Only the two
+            // exceptional cases below need to override that classification.
             results.skip_remaining = match action_result.status {
-                ActionRunStatus::CheckSucceeded
-                | ActionRunStatus::NoCheckFixSucceeded
-                | ActionRunStatus::CheckFailedFixSucceedVerifySucceed => false,
+                // --fix=false: a not-run fix should never halt the rest of the
+                // run, so every check gets a chance to report its status.
+                ActionRunStatus::CheckFailedNoRunFix => false,
                 ActionRunStatus::CheckFailedFixFailedStop => true,
-                _ => action.required(),
+                _ => match action_status {
+                    GroupExecutionStatus::Succeeded => false,
+                    GroupExecutionStatus::Skipped | GroupExecutionStatus::Failed => {
+                        action.required()
+                    }
+                },
             };
         }
 
@@ -409,7 +431,10 @@ where
                 .ok();
         }
         ActionRunStatus::CheckFailedNoRunFix => {
-            info!(target: "progress", group = group_name, name = action.name(), "Check failed, fix was not run");
+            warn!(target: "user", group = group_name, name = action.name(), "Check failed, fix was not run");
+            print_pretty_result(group_name, &action.name(), action_result)
+                .await
+                .ok();
         }
         ActionRunStatus::CheckFailedNoFixProvided => {
             error!(target: "user", group = group_name, name = action.name(), "Check failed, no fix provided");
@@ -1241,6 +1266,151 @@ mod tests {
             exit_code.failed_group
         );
         assert_eq!(BTreeSet::new(), exit_code.skipped_group);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_group_check_failed_fix_failed_stop_halts_remaining_actions() -> Result<()>
+    {
+        let mut actions = vec![make_action_run(
+            ActionRunStatus::CheckFailedFixFailedStop,
+            true,
+        )];
+        actions.extend(will_not_run());
+        let (_name, container) = make_group_action("fix-failed-stop", actions);
+        let run_groups = RunGroups {
+            group_actions: BTreeMap::new(),
+            all_paths: Vec::new(),
+            full_order: Vec::new(),
+            skipped_groups: BTreeSet::new(),
+            yolo: false,
+        };
+
+        let group_span = info_span!("test_group", "indicatif.pb_show" = true);
+        let result = run_groups.execute_group(&group_span, &container).await?;
+
+        assert!(matches!(result.status, GroupExecutionStatus::Failed));
+        assert!(result.skip_remaining);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_group_check_failed_fix_failed_stop_halts_even_when_not_required()
+    -> Result<()> {
+        // `CheckFailedFixFailedStop` is an unconditional abort signal — a fix ran and
+        // failed catastrophically — so it must halt the group even when the action
+        // is `required: false`, unlike ordinary failures which only halt if required.
+        let mut actions = vec![make_action_run(
+            ActionRunStatus::CheckFailedFixFailedStop,
+            false,
+        )];
+        actions.extend(will_not_run());
+        let (_name, container) = make_group_action("fix-failed-stop-not-required", actions);
+        let run_groups = RunGroups {
+            group_actions: BTreeMap::new(),
+            all_paths: Vec::new(),
+            full_order: Vec::new(),
+            skipped_groups: BTreeSet::new(),
+            yolo: false,
+        };
+
+        let group_span = info_span!("test_group", "indicatif.pb_show" = true);
+        let result = run_groups.execute_group(&group_span, &container).await?;
+
+        assert!(result.skip_remaining);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_group_check_failed_no_run_fix_does_not_skip_remaining_actions()
+    -> Result<()> {
+        let (_name, container) = make_group_action(
+            "fix-false",
+            vec![
+                make_action_run(ActionRunStatus::CheckFailedNoRunFix, true),
+                make_action_run(ActionRunStatus::CheckSucceeded, true),
+            ],
+        );
+        let run_groups = RunGroups {
+            group_actions: BTreeMap::new(),
+            all_paths: Vec::new(),
+            full_order: Vec::new(),
+            skipped_groups: BTreeSet::new(),
+            yolo: false,
+        };
+
+        let group_span = info_span!("test_group", "indicatif.pb_show" = true);
+        let result = run_groups.execute_group(&group_span, &container).await?;
+
+        assert!(matches!(result.status, GroupExecutionStatus::Failed));
+        assert!(!result.skip_remaining);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_check_failed_no_run_fix_does_not_halt_dependent_groups() -> Result<()> {
+        let group_actions = BTreeMap::from([
+            make_group_action(
+                "fails",
+                make_action_runs(ActionRunStatus::CheckFailedNoRunFix),
+            ),
+            make_group_action(
+                "depends_on_fails",
+                make_action_runs(ActionRunStatus::CheckSucceeded),
+            ),
+        ]);
+
+        let all_paths = vec!["fails".to_string(), "depends_on_fails".to_string()];
+        let run_groups = RunGroups {
+            group_actions,
+            full_order: all_paths.clone(),
+            all_paths,
+            skipped_groups: BTreeSet::new(),
+            yolo: false,
+        };
+
+        let exit_code = run_groups.execute().await?;
+        assert!(!exit_code.did_succeed);
+        assert_eq!(
+            BTreeSet::from(["depends_on_fails"].map(str::to_string)),
+            exit_code.succeeded_groups
+        );
+        assert_eq!(
+            BTreeSet::from(["fails"].map(str::to_string)),
+            exit_code.failed_group
+        );
+        assert_eq!(BTreeSet::new(), exit_code.skipped_group);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_execute_group_status_is_sticky_once_failed() -> Result<()> {
+        // The first action fails but is `required: false`, so it doesn't halt the
+        // group; a later action in the same group then succeeds. The group must
+        // still be reported as failed overall — a later success must not clear an
+        // earlier failure.
+        let (_name, container) = make_group_action(
+            "mixed-results",
+            vec![
+                make_action_run(ActionRunStatus::CheckFailedFixSucceedVerifyFailed, false),
+                make_action_run(ActionRunStatus::CheckSucceeded, true),
+            ],
+        );
+        let run_groups = RunGroups {
+            group_actions: BTreeMap::new(),
+            all_paths: Vec::new(),
+            full_order: Vec::new(),
+            skipped_groups: BTreeSet::new(),
+            yolo: false,
+        };
+
+        let group_span = info_span!("test_group", "indicatif.pb_show" = true);
+        let result = run_groups.execute_group(&group_span, &container).await?;
+
+        assert!(
+            matches!(result.status, GroupExecutionStatus::Failed),
+            "a later succeeding action must not clear an earlier failure"
+        );
         Ok(())
     }
 

--- a/tests/scope_doctor.rs
+++ b/tests/scope_doctor.rs
@@ -400,6 +400,37 @@ fn test_skip_only_flag_keeps_dependencies() {
 }
 
 #[test]
+fn test_fix_false_runs_every_check_and_warns_on_unrun_fixes() {
+    // Regression test for https://github.com/Gusto/scope/issues/197: `--fix=false` used to
+    // stop at the first failing required check, hiding later checks/fixes from the user.
+    let test_helper = ScopeTestHelper::new(
+        "test_fix_false_runs_every_check_and_warns_on_unrun_fixes",
+        "fix-false",
+    );
+    let result = test_helper.doctor_run(Some(&["--fix=false", "--only=fix-false"]));
+
+    result
+        .failure()
+        .stdout(predicate::str::contains(
+            "INFO Check was successful, group: \"fix-false\", name: \"succeeds\"",
+        ))
+        .stdout(predicate::str::contains(
+            "WARN Check failed, fix was not run, group: \"fix-false\", name: \"run-always-not-required\"",
+        ))
+        .stdout(predicate::str::contains(
+            "WARN Check failed, fix was not run, group: \"fix-false\", name: \"run-always-required\"",
+        ))
+        .stdout(predicate::str::contains(
+            "INFO Check was successful, group: \"fix-false\", name: \"another-action\"",
+        ))
+        .stdout(predicate::str::contains(
+            "Summary: 0 groups succeeded, 1 groups failed",
+        ));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
 fn test_yolo_flag_auto_approves_fix_prompts() {
     let test_helper = ScopeTestHelper::new(
         "test_yolo_flag_auto_approves_fix_prompts",

--- a/tests/test-cases/fix-false/.scope/group.yaml
+++ b/tests/test-cases/fix-false/.scope/group.yaml
@@ -1,0 +1,31 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: fix-false
+spec:
+  actions:
+    - name: succeeds
+      check:
+        commands:
+          - echo "succeeds"
+      fix:
+        commands:
+          - echo "fix ran"
+    - name: run-always-not-required
+      required: false
+      check: {}
+      fix:
+        commands:
+          - echo "this always runs but isn't critical"
+    - name: run-always-required
+      check: {}
+      fix:
+        commands:
+          - echo "this always runs but *is* critical"
+    - name: another-action
+      check:
+        commands:
+          - echo "another action"
+      fix:
+        commands:
+          - echo "this is another action"


### PR DESCRIPTION
## Summary

Fixes #197. `scope doctor run --fix=false` is meant to preview every problem in a repo without mutating anything, but it stopped at the first failing required check — hiding everything after it.

- A not-run fix (`--fix=false` on a failing check) no longer sets `skip_remaining`, so every check in a group (and every dependent group) still runs.
- Group status is now aggregated worst-wins (`GroupExecutionStatus::merge`) instead of overwritten per action, so a later succeeding action in the same group can no longer clear an earlier failure.
- "Check failed, fix was not run" is now logged at `WARN` (was a hidden `INFO`/`progress`-only line), and now also prints the check's captured output like its sibling failure arms.
- `skip_remaining` is derived from the shared action-status classification rather than a second independent match, so the two decisions can't silently diverge as new statuses are added.

Reproducing the issue's exact example now produces the desired output:
```
 INFO Check was successful, group: "fix-false", name: "succeeds"
 WARN Check failed, fix was not run, group: "fix-false", name: "run-always-not-required"
 WARN Check failed, fix was not run, group: "fix-false", name: "run-always-required"
 INFO Check was successful, group: "fix-false", name: "another-action"
Summary: 0 groups succeeded, 1 groups failed
```

`--fix=true` behavior is unchanged: a fix that fails on a required action still halts the run (`CheckFailedFixFailedStop` always halts; other fix failures halt via the existing `action.required()` fallback).

## Test plan

- [x] `cargo test` — full suite passes (168 lib + 27 doctor integration tests, including new coverage for the fix)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manually reproduced the issue's exact example via `cargo run -- doctor run --fix=false --progress=plain --only fix-false` — output matches the desired behavior byte-for-byte
- [x] Added unit tests in `src/doctor/runner.rs` and `src/doctor/check.rs` covering: not-run fixes don't halt within/across groups, sticky worst-wins group status, and that `CheckFailedFixFailedStop` still halts regardless of `required`
- [x] Added integration test `test_fix_false_runs_every_check_and_warns_on_unrun_fixes` with a new fixture (`tests/test-cases/fix-false/`) mirroring the issue's example
- [x] Ran coverage (cargo-llvm-cov) and mutation testing (cargo-mutants) against the changed code and closed the gaps they surfaced

🤖 Generated with [Claude Code](https://claude.com/claude-code)