### PR TITLE
Fix `scope doctor list` omitting when-required groups (#179)

### DIFF
--- a/src/doctor/commands/list.rs
+++ b/src/doctor/commands/list.rs
@@ -6,8 +6,7 @@ use tracing::instrument;
 
 use crate::doctor::runner::{GroupOrderParams, compute_group_order};
 use crate::report_stdout;
-use crate::shared::prelude::{DoctorGroup, FoundConfig};
-use crate::shared::print_details;
+use crate::shared::prelude::{DoctorGroup, FoundConfig, print_details_with_column};
 
 #[derive(Debug, Args)]
 pub struct DoctorListArgs {}
@@ -16,18 +15,24 @@ pub struct DoctorListArgs {}
 pub async fn doctor_list(found_config: &FoundConfig, _args: &DoctorListArgs) -> Result<()> {
     report_stdout!("Available checks that will run");
     let order = generate_doctor_list(found_config).clone();
-    print_details(&found_config.working_dir, &order).await;
+    let included = |group: &DoctorGroup| {
+        if group.run_by_default {
+            "Yes".to_string()
+        } else {
+            "No".to_string()
+        }
+    };
+    print_details_with_column(
+        &found_config.working_dir,
+        &order,
+        Some(("Included", &included)),
+    )
+    .await;
     Ok(())
 }
 
 pub fn generate_doctor_list(found_config: &FoundConfig) -> Vec<DoctorGroup> {
-    let all_keys = BTreeSet::from_iter(
-        found_config
-            .doctor_group
-            .iter()
-            .filter(|(_, v)| v.run_by_default)
-            .map(|(k, _)| k.to_string()),
-    );
+    let all_keys = BTreeSet::from_iter(found_config.doctor_group.keys().map(|k| k.to_string()));
     let group_order = compute_group_order(GroupOrderParams {
         groups: &found_config.doctor_group,
         desired_groups: &all_keys,

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -26,21 +26,36 @@ pub mod prelude {
     pub use super::config_load::{ConfigOptions, FoundConfig, build_config_path};
     pub use super::logging::{LoggingOpts, STDERR_WRITER, STDOUT_WRITER, progress_bar_without_pos};
     pub use super::models::prelude::*;
-    pub use super::print_details;
     pub use super::report::{
         ActionReport, ActionReportBuilder, ActionTaskReport, ActionTaskReportBuilder,
         DefaultGroupedReportBuilder, DefaultUnstructuredReportBuilder, GroupReport,
         GroupedReportBuilder, Report, ReportRenderer, UnstructuredReportBuilder,
     };
     pub use super::{CONFIG_FILE_PATH_ENV, RUN_ID_ENV_VAR};
+    pub use super::{ExtraColumn, print_details, print_details_with_column};
 }
 
 pub(crate) fn convert_to_string(input: Vec<&str>) -> Vec<String> {
     input.iter().map(|x| x.to_string()).collect()
 }
 
-pub async fn print_details<T>(working_dir: &Path, config: &Vec<T>)
+/// Header and per-row value extractor for an optional extra column in [`print_details_with_column`].
+pub type ExtraColumn<'a, T> = (&'a str, &'a dyn Fn(&T) -> String);
+
+pub async fn print_details<T>(working_dir: &Path, config: &[T])
 where
+    T: HelpMetadata,
+{
+    print_details_with_column(working_dir, config, None::<ExtraColumn<'_, T>>).await;
+}
+
+/// Same rendering as [`print_details`], with an optional extra column (header + per-row value)
+/// inserted between `Description` and `Path`.
+pub async fn print_details_with_column<T>(
+    working_dir: &Path,
+    config: &[T],
+    extra_column: Option<ExtraColumn<'_, T>>,
+) where
     T: HelpMetadata,
 {
     let max_name_length = config
@@ -50,32 +65,230 @@ where
         .unwrap_or(20);
     let max_name_length = max(max_name_length, 20) + 2;
 
-    report_stdout!(
-        "  {:max_name_length$}{:60}{}",
-        "Name".white().bold(),
-        "Description".white().bold(),
-        "Path".white().bold()
-    );
+    match extra_column {
+        Some((header, _)) => {
+            report_stdout!(
+                "  {:max_name_length$}{:60}{:10}{}",
+                "Name".white().bold(),
+                "Description".white().bold(),
+                header.white().bold(),
+                "Path".white().bold()
+            );
+        }
+        None => {
+            report_stdout!(
+                "  {:max_name_length$}{:60}{}",
+                "Name".white().bold(),
+                "Description".white().bold(),
+                "Path".white().bold()
+            );
+        }
+    }
+
     for resource in config {
-        let mut description = resource.description().to_string();
-        if description.len() > 55 {
-            description.truncate(55);
-            description = format!("{description}...");
+        let description = format_description(&resource.description());
+        let loc = format_location(&resource.metadata().file_path(), working_dir);
+
+        match &extra_column {
+            Some((_, extractor)) => {
+                report_stdout!(
+                    "- {:max_name_length$}{:60}{:10}{}",
+                    resource.full_name(),
+                    description,
+                    extractor(resource),
+                    loc
+                );
+            }
+            None => {
+                report_stdout!(
+                    "- {:max_name_length$}{:60}{}",
+                    resource.full_name(),
+                    description,
+                    loc
+                );
+            }
+        }
+    }
+}
+
+/// Truncates `description` to 55 bytes (on a char boundary) with a trailing `...` when it's
+/// longer than that; returned as-is otherwise.
+fn format_description(description: &str) -> String {
+    if description.len() > 55 {
+        format!("{}...", truncate_at_char_boundary(description, 55))
+    } else {
+        description.to_string()
+    }
+}
+
+/// Renders a resource's file path relative to `working_dir` when possible. When
+/// `pathdiff::diff_paths` can't relativize it (e.g. `file_path` is relative but `working_dir`
+/// is absolute), falls back to the last 35 bytes (on a char boundary) prefixed with `...` if
+/// longer than that, or the path unchanged otherwise.
+fn format_location(file_path: &str, working_dir: &Path) -> String {
+    match pathdiff::diff_paths(file_path, working_dir) {
+        Some(diff) => diff.display().to_string(),
+        None if file_path.len() > 35 => {
+            format!("...{}", suffix_at_char_boundary(file_path, 35))
+        }
+        None => file_path.to_string(),
+    }
+}
+
+/// Returns the longest prefix of `s` that is at most `max_bytes` long and ends on a char
+/// boundary, so multi-byte UTF-8 characters are never split.
+fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
+/// Returns the shortest suffix of `s` that is at least `s.len() - max_bytes` bytes long and
+/// starts on a char boundary, so multi-byte UTF-8 characters are never split.
+fn suffix_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+    let mut start = s.len() - max_bytes;
+    while start < s.len() && !s.is_char_boundary(start) {
+        start += 1;
+    }
+    &s[start..]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::prelude::{ModelMetadata, ModelMetadataAnnotations, ModelMetadataBuilder};
+    use std::collections::BTreeMap;
+
+    struct FakeResource {
+        metadata: ModelMetadata,
+    }
+
+    impl HelpMetadata for FakeResource {
+        fn metadata(&self) -> &ModelMetadata {
+            &self.metadata
         }
 
-        let mut loc = resource.metadata().file_path();
-        let diff_path = pathdiff::diff_paths(&loc, working_dir);
-        if let Some(diff) = diff_path {
-            loc = diff.display().to_string();
-        } else if loc.len() > 35 {
-            loc = format!("...{}", loc.split_off(loc.len() - 35));
+        fn full_name(&self) -> String {
+            "Fake/resource".to_string()
         }
+    }
 
-        report_stdout!(
-            "- {:max_name_length$}{:60}{}",
-            resource.full_name(),
-            description,
-            loc
+    fn fake_resource(description: &str, file_path: &str) -> FakeResource {
+        let metadata = ModelMetadataBuilder::default()
+            .name("fake")
+            .description(description)
+            .annotations(ModelMetadataAnnotations {
+                file_path: Some(file_path.to_string()),
+                ..Default::default()
+            })
+            .labels(BTreeMap::default())
+            .build()
+            .unwrap();
+        FakeResource { metadata }
+    }
+
+    #[tokio::test]
+    async fn print_details_truncates_multibyte_description_without_panicking() {
+        let description = format!("{}é{}", "a".repeat(54), "b".repeat(20));
+        let resource = fake_resource(&description, "/short/path.yaml");
+
+        print_details(Path::new("/tmp"), &[resource]).await;
+    }
+
+    #[tokio::test]
+    async fn print_details_truncates_multibyte_path_without_panicking() {
+        let relative_path = format!("{}é{}", "a".repeat(4), "b".repeat(34));
+        let resource = fake_resource("a description", &relative_path);
+
+        print_details(Path::new("/tmp/working"), &[resource]).await;
+    }
+
+    #[tokio::test]
+    async fn print_details_keeps_short_relative_path_as_is() {
+        // pathdiff::diff_paths returns None when `path` is relative but `base` is absolute, so
+        // this exercises the fallback branch that leaves `loc` untouched (it's already short
+        // enough to not need the "..." truncation either).
+        let resource = fake_resource("a description", "short.yaml");
+
+        print_details(Path::new("/tmp/working"), &[resource]).await;
+    }
+
+    #[test]
+    fn format_description_leaves_55_bytes_unchanged() {
+        let description = "a".repeat(55);
+
+        assert_eq!(format_description(&description), description);
+    }
+
+    #[test]
+    fn format_description_truncates_56_bytes_with_ellipsis() {
+        let description = "a".repeat(56);
+
+        assert_eq!(
+            format_description(&description),
+            format!("{}...", "a".repeat(55))
         );
+    }
+
+    #[test]
+    fn format_location_relativizes_when_possible() {
+        assert_eq!(
+            format_location("/tmp/working/child/group.yaml", Path::new("/tmp/working")),
+            "child/group.yaml"
+        );
+    }
+
+    #[test]
+    fn format_location_leaves_35_byte_unrelativizable_path_unchanged() {
+        let file_path = "a".repeat(35);
+
+        assert_eq!(
+            format_location(&file_path, Path::new("/tmp/working")),
+            file_path
+        );
+    }
+
+    #[test]
+    fn format_location_truncates_36_byte_unrelativizable_path_with_ellipsis() {
+        let file_path = "a".repeat(36);
+
+        assert_eq!(
+            format_location(&file_path, Path::new("/tmp/working")),
+            format!("...{}", "a".repeat(35))
+        );
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_never_splits_a_multibyte_char() {
+        let description = format!("{}é{}", "a".repeat(54), "b".repeat(20));
+
+        assert_eq!(truncate_at_char_boundary(&description, 55), "a".repeat(54));
+    }
+
+    #[test]
+    fn truncate_at_char_boundary_returns_input_unchanged_when_within_limit() {
+        assert_eq!(truncate_at_char_boundary("short", 55), "short");
+    }
+
+    #[test]
+    fn suffix_at_char_boundary_never_splits_a_multibyte_char() {
+        let path = format!("{}é{}", "a".repeat(4), "b".repeat(34));
+
+        // The raw byte offset (path.len() - 35 = 5) lands inside "é" (bytes 4..6), so the
+        // returned suffix rounds forward to the next boundary rather than splitting the char.
+        assert_eq!(suffix_at_char_boundary(&path, 35), "b".repeat(34));
+    }
+
+    #[test]
+    fn suffix_at_char_boundary_returns_input_unchanged_when_within_limit() {
+        assert_eq!(suffix_at_char_boundary("short", 35), "short");
     }
 }

--- a/tests/scope_doctor.rs
+++ b/tests/scope_doctor.rs
@@ -48,9 +48,48 @@ fn test_doctor_list() {
 
     result
         .success()
+        .stdout(predicate::str::contains("Included"))
         .stdout(predicate::str::contains("ScopeDoctorGroup/path-exists"))
         .stdout(predicate::str::contains("Check if file exists"))
         .stdout(predicate::str::contains(".scope/group.yaml"));
+
+    test_helper.clean_work_dir();
+}
+
+#[test]
+fn test_doctor_list_includes_when_required_groups() {
+    let test_helper = ScopeTestHelper::new(
+        "test_doctor_list_includes_when_required_groups",
+        "list-with-when-required",
+    );
+    let result = test_helper
+        .run_command(&["doctor", "list"])
+        .success()
+        .stdout(predicate::str::contains(
+            "ScopeDoctorGroup/when-required-group",
+        ))
+        .stdout(predicate::str::contains("ScopeDoctorGroup/default-group"));
+
+    let output = result.get_output().stdout.clone();
+    let stdout = String::from_utf8(output).expect("stdout should be utf8");
+
+    let default_line = stdout
+        .lines()
+        .find(|line| line.contains("ScopeDoctorGroup/default-group"))
+        .expect("default-group line should be present");
+    assert!(
+        default_line.contains("Yes"),
+        "expected default-group to be marked Included: Yes, got: {default_line}"
+    );
+
+    let when_required_line = stdout
+        .lines()
+        .find(|line| line.contains("ScopeDoctorGroup/when-required-group"))
+        .expect("when-required-group line should be present");
+    assert!(
+        when_required_line.contains("No"),
+        "expected when-required-group to be marked Included: No, got: {when_required_line}"
+    );
 
     test_helper.clean_work_dir();
 }

--- a/tests/test-cases/list-with-when-required/.scope/default-group.yaml
+++ b/tests/test-cases/list-with-when-required/.scope/default-group.yaml
@@ -1,0 +1,14 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: default-group
+  description: Runs automatically
+spec:
+  actions:
+    - name: file-exists
+      check:
+        commands:
+          - test -f {{ working_dir }}/file-mod.txt
+      fix:
+        commands:
+          - touch {{ working_dir }}/file-mod.txt

--- a/tests/test-cases/list-with-when-required/.scope/when-required-group.yaml
+++ b/tests/test-cases/list-with-when-required/.scope/when-required-group.yaml
@@ -1,0 +1,15 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: when-required-group
+  description: Only runs when required
+spec:
+  include: when-required
+  actions:
+    - name: file-exists
+      check:
+        commands:
+          - test -f {{ working_dir }}/file-bar.txt
+      fix:
+        commands:
+          - touch {{ working_dir }}/file-bar.txt


### PR DESCRIPTION
Fixes #179.

## Summary

`doctor list` only seeded its output from `include: by-default` groups, then pulled in `when-required` groups only if some default group transitively depended on them. An isolated `when-required` group — the exact case in the issue, `doctor-group-fail.yaml` — never showed up, even though nothing stops you running it directly with `--only`. Now `generate_doctor_list` seeds from every discovered group, so the list is actually complete.

Also added an `Included` column (Yes/No) so it's obvious at a glance which groups run by default vs. only when required — the issue asked for something like this too.

While I was in `print_details`, I found two latent panics (`String::truncate`/`split_off` on a raw byte offset, which blows up if that offset lands mid multi-byte UTF-8 char) and fixed those, and pulled the doctor-list-specific rendering into `print_details` via a new `print_details_with_column` helper instead of leaving a copy-pasted duplicate around.

## Test plan

- [x] Reproduced the bug against `examples/` before fixing anything — confirmed only 4 of 10 groups showed up, matching the issue exactly.
  ```console
  $ cargo run -- doctor list --working-dir examples
  Available checks that will run
    Name                          Description                                                 Path
  - ScopeDoctorGroup/noop-1       Sleep Test to validate UI                                   .../noop-1.yaml
  - ScopeDoctorGroup/noop-2       Sleep test to show UX                                       .../noop-2.yaml
  - ScopeDoctorGroup/path-exists  Check your shell for basic functionality                    .../reference-scripts.yaml
  - ScopeDoctorGroup/templated    Silence any app specific MOTDs                              .../doctor-group-templated.yaml
  ```
- [x] After the fix, same command shows all 10 groups with the new `Included` column:
  ```console
  $ cargo run -- doctor list --working-dir examples
  Available checks that will run
    Name                                    Description                                                 Included  Path
  - ScopeDoctorGroup/caching-on-files       Check if status.txt contains 'ready', fix if not            No        .../caching-on-files.yaml
  - ScopeDoctorGroup/doctor-group-auto-fix  Works along with the known-error-action-failed and veri...  No        .../auto-fix/doctor-group-auto-fix.yaml
  - ScopeDoctorGroup/fail                   Sleep then fail                                             No        .../doctor-group-fail.yaml
  - ScopeDoctorGroup/fix-failed             This will always fail the fix step...                       No        .../fix-failed.yaml
  - ScopeDoctorGroup/home-directory         Cache on a file in user's home directory                    No        .../home-directory.yaml
  - ScopeDoctorGroup/noop-1                 Sleep Test to validate UI                                   Yes       .../noop-1.yaml
  - ScopeDoctorGroup/noop-2                 Sleep test to show UX                                       Yes       .../noop-2.yaml
  - ScopeDoctorGroup/path-exists            Check your shell for basic functionality                    Yes       .../reference-scripts.yaml
  - ScopeDoctorGroup/prompt                 Ask user if they want to run the fix                        No        .../doctor-group-prompt.yaml
  - ScopeDoctorGroup/templated              Silence any app specific MOTDs                              Yes       .../doctor-group-templated.yaml
  ```
- [x] Added `tests/test-cases/list-with-when-required` fixture and `test_doctor_list_includes_when_required_groups` as a regression test.
- [x] Added unit tests that reproduced the two char-boundary panics against the original code (`#[should_panic]`), then turned them into regression tests against the fix. Also ran `cargo-mutants` against `src/shared/mod.rs` — mutation score went from ~75% to ~90%; the handful of remaining survivors are equivalent mutants (loop bounds that behave identically either way) or timeouts (infinite-loop mutants that'd fail CI on their own), not real coverage gaps.
- [x] `cargo test`, `cargo fmt --check`, and `cargo clippy --all-targets -- -D warnings` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)