### PR TITLE
Pass regex capture groups to known-error help text and fixes

### DIFF
--- a/examples/v1alpha/KnownErrorWithCapture.yaml
+++ b/examples/v1alpha/KnownErrorWithCapture.yaml
@@ -1,0 +1,13 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: not-executable
+  description: Detects a permission-denied error and makes the named file executable
+spec:
+  pattern: "permission denied: \\./(?<file>.*)"
+  help: "The file '{{ file }}' is not executable. Run `chmod +x {{ file }}` and try again."
+  fix:
+    prompt:
+      text: "Make '{{ file }}' executable?"
+    commands:
+      - chmod +x {{ file }}

--- a/schema/merged.json
+++ b/schema/merged.json
@@ -217,7 +217,7 @@
       ]
     },
     "KnownErrorPattern": {
-      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.\n\nCapture groups in a matched pattern are available in `help` and in `fix`'s `commands` and\n`prompt`: a positional group like `(.*)` is substituted with `{{ captures[1] }}` (`captures[0]`\nis the whole match), and a named group like `(?<file>.*)` is substituted with `{{ file }}`.\nWhen multiple patterns are given, the first one that matches supplies the captures.",
       "anyOf": [
         {
           "description": "A single regex pattern.",
@@ -238,7 +238,7 @@
       "type": "object",
       "properties": {
         "fix": {
-          "description": "An optional fix the user will be prompted to run.",
+          "description": "An optional fix the user will be prompted to run. Its `commands` and `prompt` may\nreference `pattern`'s capture groups, e.g. `{{ captures[1] }}` or `{{ name }}` for a named\ngroup.",
           "anyOf": [
             {
               "$ref": "#/$defs/DoctorFixSpec"
@@ -249,7 +249,7 @@
           ]
         },
         "help": {
-          "description": "Text that the user can use to fix the issue",
+          "description": "Text that the user can use to fix the issue. May reference `pattern`'s capture groups,\ne.g. `{{ captures[1] }}` or `{{ name }}` for a named group.",
           "type": "string"
         },
         "pattern": {

--- a/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -233,7 +233,7 @@
       ]
     },
     "KnownErrorPattern": {
-      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.\n\nCapture groups in a matched pattern are available in `help` and in `fix`'s `commands` and\n`prompt`: a positional group like `(.*)` is substituted with `{{ captures[1] }}` (`captures[0]`\nis the whole match), and a named group like `(?<file>.*)` is substituted with `{{ file }}`.\nWhen multiple patterns are given, the first one that matches supplies the captures.",
       "anyOf": [
         {
           "description": "A single regex pattern.",
@@ -254,7 +254,7 @@
       "type": "object",
       "properties": {
         "fix": {
-          "description": "An optional fix the user will be prompted to run.",
+          "description": "An optional fix the user will be prompted to run. Its `commands` and `prompt` may\nreference `pattern`'s capture groups, e.g. `{{ captures[1] }}` or `{{ name }}` for a named\ngroup.",
           "anyOf": [
             {
               "$ref": "#/$defs/DoctorFixSpec"
@@ -265,7 +265,7 @@
           ]
         },
         "help": {
-          "description": "Text that the user can use to fix the issue",
+          "description": "Text that the user can use to fix the issue. May reference `pattern`'s capture groups,\ne.g. `{{ captures[1] }}` or `{{ name }}` for a named group.",
           "type": "string"
         },
         "pattern": {

--- a/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -233,7 +233,7 @@
       ]
     },
     "KnownErrorPattern": {
-      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.\n\nCapture groups in a matched pattern are available in `help` and in `fix`'s `commands` and\n`prompt`: a positional group like `(.*)` is substituted with `{{ captures[1] }}` (`captures[0]`\nis the whole match), and a named group like `(?<file>.*)` is substituted with `{{ file }}`.\nWhen multiple patterns are given, the first one that matches supplies the captures.",
       "anyOf": [
         {
           "description": "A single regex pattern.",
@@ -254,7 +254,7 @@
       "type": "object",
       "properties": {
         "fix": {
-          "description": "An optional fix the user will be prompted to run.",
+          "description": "An optional fix the user will be prompted to run. Its `commands` and `prompt` may\nreference `pattern`'s capture groups, e.g. `{{ captures[1] }}` or `{{ name }}` for a named\ngroup.",
           "anyOf": [
             {
               "$ref": "#/$defs/DoctorFixSpec"
@@ -265,7 +265,7 @@
           ]
         },
         "help": {
-          "description": "Text that the user can use to fix the issue",
+          "description": "Text that the user can use to fix the issue. May reference `pattern`'s capture groups,\ne.g. `{{ captures[1] }}` or `{{ name }}` for a named group.",
           "type": "string"
         },
         "pattern": {

--- a/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -233,7 +233,7 @@
       ]
     },
     "KnownErrorPattern": {
-      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.",
+      "description": "One or more regexes that determine whether a log line matches this known error.\nAccepts either a single pattern string or a list of pattern strings; a line matching\nany one of the patterns triggers the error.\n\nCapture groups in a matched pattern are available in `help` and in `fix`'s `commands` and\n`prompt`: a positional group like `(.*)` is substituted with `{{ captures[1] }}` (`captures[0]`\nis the whole match), and a named group like `(?<file>.*)` is substituted with `{{ file }}`.\nWhen multiple patterns are given, the first one that matches supplies the captures.",
       "anyOf": [
         {
           "description": "A single regex pattern.",
@@ -254,7 +254,7 @@
       "type": "object",
       "properties": {
         "fix": {
-          "description": "An optional fix the user will be prompted to run.",
+          "description": "An optional fix the user will be prompted to run. Its `commands` and `prompt` may\nreference `pattern`'s capture groups, e.g. `{{ captures[1] }}` or `{{ name }}` for a named\ngroup.",
           "anyOf": [
             {
               "$ref": "#/$defs/DoctorFixSpec"
@@ -265,7 +265,7 @@
           ]
         },
         "help": {
-          "description": "Text that the user can use to fix the issue",
+          "description": "Text that the user can use to fix the issue. May reference `pattern`'s capture groups,\ne.g. `{{ captures[1] }}` or `{{ name }}` for a named group.",
           "type": "string"
         },
         "pattern": {

--- a/src/doctor/check.rs
+++ b/src/doctor/check.rs
@@ -1571,14 +1571,14 @@ pub(crate) mod tests {
 
     mod analyze_known_errors_spec {
         use super::*;
-        use crate::models::prelude::{ModelMetadata, ModelMetadataAnnotations};
+        use crate::models::prelude::{DoctorFixSpec, ModelMetadata, ModelMetadataAnnotations};
         use crate::shared::analyze::AnalyzeStatus;
-        use regex::RegexSet;
+        use regex::Regex;
 
         fn make_known_error(pattern: &str, with_fix: bool) -> KnownError {
             let fix = if with_fix {
-                Some(DoctorFix {
-                    command: Some(DoctorCommands::from(vec!["true"])),
+                Some(DoctorFixSpec {
+                    commands: vec!["true".to_string()],
                     help_text: None,
                     help_url: None,
                     prompt: None,
@@ -1601,7 +1601,7 @@ pub(crate) mod tests {
                     },
                     labels: BTreeMap::new(),
                 },
-                regexes: RegexSet::new([pattern]).unwrap(),
+                regexes: vec![Regex::new(pattern).unwrap()],
                 help_text: "test help".to_string(),
                 fix,
             }
@@ -1692,6 +1692,29 @@ pub(crate) mod tests {
             let status = run.analyze_known_errors(&[report]).await?;
 
             assert!(matches!(status, AnalyzeStatus::KnownErrorFoundNoFixFound));
+            Ok(())
+        }
+
+        // help_text predates capture substitution and may contain brace-like literal text that
+        // isn't valid template syntax; that must not abort the run.
+        #[tokio::test]
+        async fn malformed_help_text_template_falls_back_to_raw_text() -> Result<()> {
+            let action = build_run_fail_fix_succeed_action();
+            let exec_runner = MockExecutionProvider::new();
+            let glob_walker = MockGlobWalker::new();
+            let mut run = setup_test(vec![action], exec_runner, glob_walker);
+
+            run.working_dir = PathBuf::from("/tmp");
+            run.yolo = true;
+            let mut known_error = make_known_error("error-pattern", true);
+            known_error.help_text = "Error code {500} occurred, 50% done, {% if".to_string();
+            run.known_errors
+                .insert("ScopeKnownError/test-error".to_string(), known_error);
+
+            let report = task_report("error-pattern found in output");
+            let status = run.analyze_known_errors(&[report]).await?;
+
+            assert!(matches!(status, AnalyzeStatus::KnownErrorFoundFixSucceeded));
             Ok(())
         }
     }

--- a/src/models/v1alpha/known_error.rs
+++ b/src/models/v1alpha/known_error.rs
@@ -22,6 +22,11 @@ fn non_empty_string_list(generator: &mut schemars::generate::SchemaGenerator) ->
 /// One or more regexes that determine whether a log line matches this known error.
 /// Accepts either a single pattern string or a list of pattern strings; a line matching
 /// any one of the patterns triggers the error.
+///
+/// Capture groups in a matched pattern are available in `help` and in `fix`'s `commands` and
+/// `prompt`: a positional group like `(.*)` is substituted with `{{ captures[1] }}` (`captures[0]`
+/// is the whole match), and a named group like `(?<file>.*)` is substituted with `{{ file }}`.
+/// When multiple patterns are given, the first one that matches supplies the captures.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(untagged)]
 pub enum KnownErrorPattern {
@@ -46,7 +51,8 @@ impl KnownErrorPattern {
 #[serde(rename_all = "camelCase")]
 #[schemars(deny_unknown_fields)]
 pub struct KnownErrorSpec {
-    /// Text that the user can use to fix the issue
+    /// Text that the user can use to fix the issue. May reference `pattern`'s capture groups,
+    /// e.g. `{{ captures[1] }}` or `{{ name }}` for a named group.
     pub help: String,
 
     /// A regex (or list of regexes) used to determine if the line is an error.
@@ -54,7 +60,9 @@ pub struct KnownErrorSpec {
     /// pattern matches.
     pub pattern: KnownErrorPattern,
 
-    /// An optional fix the user will be prompted to run.
+    /// An optional fix the user will be prompted to run. Its `commands` and `prompt` may
+    /// reference `pattern`'s capture groups, e.g. `{{ captures[1] }}` or `{{ name }}` for a named
+    /// group.
     pub fix: Option<DoctorFixSpec>,
 }
 
@@ -121,6 +129,7 @@ impl InternalScopeModel<KnownErrorSpec, V1AlphaKnownError> for V1AlphaKnownError
         vec![
             "v1alpha/KnownError.yaml".to_string(),
             "v1alpha/KnownErrorMultiPattern.yaml".to_string(),
+            "v1alpha/KnownErrorWithCapture.yaml".to_string(),
         ]
     }
 }

--- a/src/shared/analyze/mod.rs
+++ b/src/shared/analyze/mod.rs
@@ -1,12 +1,12 @@
 use crate::models::HelpMetadata;
 use crate::prelude::{
     CaptureOpts, DefaultExecutionProvider, DoctorFix, ExecutionProvider, KnownError, OutputCapture,
-    OutputDisplay, generate_env_vars,
+    OutputDisplay, generate_env_vars, substitute_templates_with_captures,
 };
 use anyhow::Result;
 use inquire::InquireError;
 use std::collections::BTreeMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::io::{AsyncBufReadExt, AsyncRead};
 use tracing::{debug, error, info, warn};
 
@@ -34,17 +34,46 @@ where
         let mut known_errors_to_remove = Vec::new();
         for (name, ke) in &known_errors {
             debug!("Checking known error {}", ke.name());
-            if ke.regexes.is_match(&line) {
+            if let Some(captures) = ke.find_match(&line) {
                 warn!(target: "always", "Known error '{}' found on line {}", ke.name(), line_number);
-                info!(target: "always", "\t==> {}", ke.help_text);
+
+                let ke_working_dir = ke
+                    .metadata
+                    .annotations
+                    .working_dir
+                    .as_ref()
+                    .expect("known error metadata should have a working_dir");
+                // Help text predates capture substitution and may contain brace-like literal
+                // text that isn't valid template syntax; fall back to the raw text rather than
+                // aborting the run over a cosmetic rendering failure.
+                let help_text =
+                    substitute_templates_with_captures(ke_working_dir, &ke.help_text, &captures)
+                        .unwrap_or_else(|err| {
+                            debug!(
+                                "Failed to render help text for known error '{}': {}",
+                                ke.name(),
+                                err
+                            );
+                            ke.help_text.clone()
+                        });
+                info!(target: "always", "\t==> {}", help_text);
 
                 result = match &ke.fix {
-                    Some(fix) => {
+                    Some(fix_spec) => {
                         info!(target: "always", "found a fix!");
+
+                        let containing_dir_string = ke.metadata.containing_dir();
+                        let containing_dir = Path::new(&containing_dir_string);
+                        let fix = DoctorFix::from_spec_with_captures(
+                            containing_dir,
+                            ke_working_dir,
+                            fix_spec.clone(),
+                            &captures,
+                        )?;
 
                         tracing_indicatif::suspend_tracing_indicatif(|| {
                             let exec_path = ke.metadata.exec_path();
-                            prompt_and_run_fix(working_dir, exec_path, fix, yolo)
+                            prompt_and_run_fix(working_dir, exec_path, &fix, yolo)
                         })
                         .await?
                     }

--- a/src/shared/models/internal/command.rs
+++ b/src/shared/models/internal/command.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use derive_builder::Builder;
 use std::path::Path;
 
-use super::{extract_command_path, substitute_templates};
+use super::{RegexCaptures, extract_command_path, substitute_templates_with_captures};
 
 #[derive(Debug, PartialEq, Clone, Builder)]
 pub struct DoctorCommand {
@@ -11,7 +11,23 @@ pub struct DoctorCommand {
 
 impl DoctorCommand {
     pub fn try_new(containing_dir: &Path, working_dir: &str, command: &str) -> Result<Self> {
-        let cmd = substitute_templates(working_dir, command)?;
+        Self::try_new_with_captures(
+            containing_dir,
+            working_dir,
+            command,
+            &RegexCaptures::default(),
+        )
+    }
+
+    /// Like `try_new`, but also substitutes regex capture groups (e.g. `{{ captures[1] }}` or
+    /// `{{ name }}` for a named group) matched from a `ScopeKnownError` pattern.
+    pub fn try_new_with_captures(
+        containing_dir: &Path,
+        working_dir: &str,
+        command: &str,
+        captures: &RegexCaptures,
+    ) -> Result<Self> {
+        let cmd = substitute_templates_with_captures(working_dir, command, captures)?;
         let cmd = extract_command_path(containing_dir, &cmd);
         let cmd = Self::expand_command(&cmd);
         Ok(DoctorCommand::from_str(&cmd))
@@ -57,9 +73,27 @@ impl DoctorCommands {
         working_dir: &str,
         commands: &[String],
     ) -> Result<DoctorCommands> {
+        Self::from_commands_with_captures(
+            containing_dir,
+            working_dir,
+            commands,
+            &RegexCaptures::default(),
+        )
+    }
+
+    /// Like `from_commands`, but also substitutes regex capture groups matched from a
+    /// `ScopeKnownError` pattern into each command.
+    pub fn from_commands_with_captures(
+        containing_dir: &Path,
+        working_dir: &str,
+        commands: &[String],
+        captures: &RegexCaptures,
+    ) -> Result<DoctorCommands> {
         commands
             .iter()
-            .map(|command| DoctorCommand::try_new(containing_dir, working_dir, command))
+            .map(|command| {
+                DoctorCommand::try_new_with_captures(containing_dir, working_dir, command, captures)
+            })
             .collect::<Result<Vec<_>>>()
             .map(|commands| DoctorCommands { commands })
     }

--- a/src/shared/models/internal/fix.rs
+++ b/src/shared/models/internal/fix.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use derive_builder::Builder;
 
+use super::{RegexCaptures, substitute_templates_with_captures};
+
 #[derive(Debug, PartialEq, Clone, Builder)]
 #[builder(setter(into))]
 pub struct DoctorFix {
@@ -47,6 +49,39 @@ impl DoctorFix {
             prompt,
         })
     }
+
+    /// Like `from_spec`, but also substitutes regex capture groups matched from a
+    /// `ScopeKnownError` pattern into the fix's commands, help text, and prompt.
+    pub fn from_spec_with_captures(
+        containing_dir: &Path,
+        working_dir: &str,
+        fix: DoctorFixSpec,
+        captures: &RegexCaptures,
+    ) -> Result<Self> {
+        let commands = DoctorCommands::from_commands_with_captures(
+            containing_dir,
+            working_dir,
+            &fix.commands,
+            captures,
+        )?;
+        let help_text = fix
+            .help_text
+            .as_ref()
+            .map(|st| substitute_templates_with_captures(working_dir, st.trim(), captures))
+            .transpose()?;
+        let help_url = fix.help_url.clone();
+        let prompt = fix
+            .prompt
+            .map(|p| DoctorFixPrompt::from_spec_with_captures(p, working_dir, captures))
+            .transpose()?;
+
+        Ok(DoctorFix {
+            command: Some(commands),
+            help_text,
+            help_url,
+            prompt,
+        })
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Builder)]
@@ -64,6 +99,26 @@ impl From<DoctorFixPromptSpec> for DoctorFixPrompt {
             text: value.text,
             extra_context: value.extra_context,
         }
+    }
+}
+
+impl DoctorFixPrompt {
+    fn from_spec_with_captures(
+        value: DoctorFixPromptSpec,
+        working_dir: &str,
+        captures: &RegexCaptures,
+    ) -> Result<Self> {
+        let text = substitute_templates_with_captures(working_dir, &value.text, captures)?;
+        let extra_context = value
+            .extra_context
+            .as_ref()
+            .map(|ctx| substitute_templates_with_captures(working_dir, ctx, captures))
+            .transpose()?;
+
+        Ok(DoctorFixPrompt {
+            text,
+            extra_context,
+        })
     }
 }
 
@@ -140,5 +195,119 @@ mod tests {
         let actual = DoctorFix::from_spec(Path::new("/some/dir"), "/some/work/dir", spec).unwrap();
 
         assert_eq!(expected, actual)
+    }
+
+    #[test]
+    fn from_spec_with_captures_substitutes_commands_help_and_prompt() {
+        let mut named = std::collections::BTreeMap::new();
+        named.insert("file".to_string(), "foo.sh".to_string());
+        let captures = RegexCaptures {
+            positional: vec![
+                "permission denied: ./foo.sh".to_string(),
+                "foo.sh".to_string(),
+            ],
+            named,
+        };
+
+        let spec = DoctorFixSpec {
+            commands: vec!["sudo chmod +x {{ file }}".to_string()],
+            help_text: Some("Run `chmod +x {{ captures[1] }}` and try again.".to_string()),
+            help_url: None,
+            prompt: Some(DoctorFixPromptSpec {
+                text: "Fix {{ file }}?".to_string(),
+                extra_context: Some("Matched: {{ captures[0] }}".to_string()),
+            }),
+        };
+
+        let actual = DoctorFix::from_spec_with_captures(
+            Path::new("/some/dir"),
+            "/some/work/dir",
+            spec,
+            &captures,
+        )
+        .unwrap();
+
+        assert_eq!(
+            actual.command.unwrap().iter().next().unwrap().text(),
+            "sudo chmod +x foo.sh"
+        );
+        assert_eq!(
+            actual.help_text.unwrap(),
+            "Run `chmod +x foo.sh` and try again."
+        );
+        let prompt = actual.prompt.unwrap();
+        assert_eq!(prompt.text, "Fix foo.sh?");
+        assert_eq!(
+            prompt.extra_context.unwrap(),
+            "Matched: permission denied: ./foo.sh"
+        );
+    }
+
+    #[test]
+    fn from_spec_with_captures_defaults_match_from_spec() {
+        let spec = DoctorFixSpec {
+            commands: vec!["./script.sh".to_string()],
+            help_text: Some("some help".to_string()),
+            help_url: None,
+            prompt: None,
+        };
+
+        let expected =
+            DoctorFix::from_spec(Path::new("/some/dir"), "/some/work/dir", spec.clone()).unwrap();
+        let actual = DoctorFix::from_spec_with_captures(
+            Path::new("/some/dir"),
+            "/some/work/dir",
+            spec,
+            &RegexCaptures::default(),
+        )
+        .unwrap();
+
+        assert_eq!(expected, actual)
+    }
+
+    #[test]
+    fn from_spec_with_captures_handles_no_help_text_or_prompt() {
+        let spec = DoctorFixSpec {
+            commands: vec!["true".to_string()],
+            help_text: None,
+            help_url: None,
+            prompt: None,
+        };
+
+        let actual = DoctorFix::from_spec_with_captures(
+            Path::new("/some/dir"),
+            "/some/work/dir",
+            spec,
+            &RegexCaptures::default(),
+        )
+        .unwrap();
+
+        assert_eq!(actual.help_text, None);
+        assert_eq!(actual.prompt, None);
+    }
+
+    #[test]
+    fn from_spec_with_captures_handles_prompt_with_no_extra_context() {
+        let spec = DoctorFixSpec {
+            commands: vec!["true".to_string()],
+            help_text: None,
+            help_url: None,
+            prompt: Some(DoctorFixPromptSpec {
+                text: "do the thing?".to_string(),
+                extra_context: None,
+            }),
+        };
+
+        let actual = DoctorFix::from_spec_with_captures(
+            Path::new("/some/dir"),
+            "/some/work/dir",
+            spec,
+            &RegexCaptures::default(),
+        )
+        .unwrap();
+
+        let prompt = actual.prompt.unwrap();
+        assert_eq!(prompt.text, "do the thing?");
+        assert_eq!(prompt.extra_context, None);
     }
 }

--- a/src/shared/models/internal/known_error.rs
+++ b/src/shared/models/internal/known_error.rs
@@ -1,11 +1,17 @@
 use std::path::Path;
 
 use crate::models::HelpMetadata;
-use crate::models::prelude::{ModelMetadata, V1AlphaKnownError};
+use crate::models::prelude::{DoctorFixSpec, ModelMetadata, V1AlphaKnownError};
 use derivative::Derivative;
-use regex::RegexSet;
+use regex::Regex;
 
+use super::RegexCaptures;
 use super::fix::DoctorFix;
+
+/// Template variable names reserved for `working_dir` and positional captures; a named capture
+/// group using one of these would otherwise silently shadow the reserved variable when
+/// substituted into a fix's commands/help/prompt.
+const RESERVED_CAPTURE_NAMES: [&str; 2] = ["working_dir", "captures"];
 
 #[derive(Derivative)]
 #[derivative(PartialEq)]
@@ -14,15 +20,40 @@ pub struct KnownError {
     pub full_name: String,
     pub metadata: ModelMetadata,
     #[derivative(PartialEq = "ignore")]
-    pub regexes: RegexSet,
+    pub regexes: Vec<Regex>,
     pub help_text: String,
-    pub fix: Option<DoctorFix>,
+    pub fix: Option<DoctorFixSpec>,
 }
 
 impl KnownError {
     /// Returns the original pattern strings in the order they were defined.
-    pub fn patterns(&self) -> &[String] {
-        self.regexes.patterns()
+    pub fn patterns(&self) -> Vec<String> {
+        self.regexes
+            .iter()
+            .map(|r| r.as_str().to_string())
+            .collect()
+    }
+
+    /// Returns the capture groups (positional and named) of the first pattern that matches
+    /// `line`, if any, ready to substitute into fix commands / help text templates.
+    /// When multiple patterns are defined, the first one (in definition order) that matches wins.
+    pub fn find_match(&self, line: &str) -> Option<RegexCaptures> {
+        self.regexes.iter().find_map(|r| {
+            let caps = r.captures(line)?;
+            let positional = caps
+                .iter()
+                .map(|m| m.map(|m| m.as_str().to_string()).unwrap_or_default())
+                .collect();
+            let named = r
+                .capture_names()
+                .flatten()
+                .filter_map(|name| {
+                    caps.name(name)
+                        .map(|m| (name.to_string(), m.as_str().to_string()))
+                })
+                .collect();
+            Some(RegexCaptures { positional, named })
+        })
     }
 }
 
@@ -47,8 +78,22 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
                 value.full_name()
             );
         }
-        // RegexSet::new accepts empty iterators, so the guard above is required.
-        let regexes = RegexSet::new(&patterns)?;
+        let regexes = patterns
+            .iter()
+            .map(|p| Regex::new(p))
+            .collect::<Result<Vec<_>, _>>()?;
+
+        for regex in &regexes {
+            for name in regex.capture_names().flatten() {
+                if RESERVED_CAPTURE_NAMES.contains(&name) {
+                    anyhow::bail!(
+                        "known error '{}' has a pattern with a capture group named '{}', which is reserved for template substitution",
+                        value.full_name(),
+                        name
+                    );
+                }
+            }
+        }
 
         let binding = value.metadata.containing_dir();
         let containing_dir = Path::new(&binding);
@@ -57,24 +102,30 @@ impl TryFrom<V1AlphaKnownError> for KnownError {
             .annotations
             .working_dir
             .as_ref()
-            .unwrap()
+            .expect("model metadata should always have a working_dir set during config loading")
             .clone();
 
-        let maybe_fix = match value.spec.fix {
-            Some(ref fix) => Some(DoctorFix::from_spec(
+        // The fix (if any) isn't built here: its commands, help text, and prompt may reference
+        // capture groups from `pattern`, which aren't known until a line actually matches. The
+        // raw spec is turned into a `DoctorFix` at match time instead (see
+        // `DoctorFix::from_spec_with_captures`). It's still validated here (with no captures
+        // available) so a broken fix template fails fast at config-load time rather than only
+        // surfacing once a matching line is intercepted.
+        if let Some(ref fix) = value.spec.fix {
+            DoctorFix::from_spec_with_captures(
                 containing_dir,
                 &working_dir,
                 fix.clone(),
-            )?),
-            None => None,
-        };
+                &RegexCaptures::default(),
+            )?;
+        }
 
         Ok(KnownError {
             full_name: value.full_name(),
             metadata: value.metadata,
             regexes,
             help_text: value.spec.help,
-            fix: maybe_fix,
+            fix: value.spec.fix,
         })
     }
 }
@@ -134,7 +185,7 @@ spec:
             "The command had an error, try reading the logs around there to find out what happened.",
             model.help_text
         );
-        assert_eq!(["error"], model.patterns());
+        assert_eq!(model.patterns(), ["error"]);
     }
 
     #[test]
@@ -156,7 +207,7 @@ spec:
         let model = configs[0].get_known_error_spec().unwrap();
 
         assert_eq!("multi-error", model.metadata.name);
-        assert_eq!(["first error", "second error"], model.patterns());
+        assert_eq!(model.patterns(), ["first error", "second error"]);
         assert_eq!(2, model.regexes.len());
     }
 
@@ -212,21 +263,14 @@ spec:
         let actual = KnownError::try_from(input.clone()).unwrap();
 
         // regexes is PartialEq-ignored; check patterns explicitly.
-        assert_eq!(["some regex pattern"], actual.patterns());
+        assert_eq!(actual.patterns(), ["some regex pattern"]);
         assert_eq!(
             KnownError {
                 full_name: "ScopeKnownError/some test error".to_string(),
                 metadata: input.metadata,
-                regexes: RegexSet::new(["some regex pattern"]).unwrap(),
+                regexes: vec![Regex::new("some regex pattern").unwrap()],
                 help_text: input.spec.help,
-                fix: Some(
-                    DoctorFix::from_spec(
-                        Path::new(&model_metadata.containing_dir()),
-                        &model_metadata.annotations.working_dir.unwrap(),
-                        input.spec.fix.unwrap()
-                    )
-                    .unwrap()
-                ),
+                fix: input.spec.fix,
             },
             actual
         )
@@ -257,10 +301,104 @@ spec:
 
         let actual = KnownError::try_from(input).unwrap();
 
-        assert_eq!(["alpha error", "beta error"], actual.patterns());
+        assert_eq!(actual.patterns(), ["alpha error", "beta error"]);
         assert_eq!(2, actual.regexes.len());
-        assert!(actual.regexes.is_match("alpha error in output"));
-        assert!(actual.regexes.is_match("beta error in output"));
-        assert!(!actual.regexes.is_match("unrelated line"));
+        assert!(actual.find_match("alpha error in output").is_some());
+        assert!(actual.find_match("beta error in output").is_some());
+        assert!(actual.find_match("unrelated line").is_none());
+    }
+
+    #[test]
+    fn find_match_exposes_positional_and_named_capture_groups() {
+        let model_metadata = make_metadata(
+            "not-executable",
+            "/foo/bar/file.yaml",
+            "/foo/bar",
+            "/some/work/dir",
+        );
+
+        let input = V1AlphaKnownError {
+            api_version: V1AlphaApiVersion::ScopeV1Alpha,
+            kind: KnownErrorKind::ScopeKnownError,
+            metadata: model_metadata,
+            spec: KnownErrorSpec {
+                help: "The script is not executable.".to_string(),
+                pattern: KnownErrorPattern::Single(
+                    r"permission denied: \./(?<file>.*)".to_string(),
+                ),
+                fix: None,
+            },
+        };
+
+        let actual = KnownError::try_from(input).unwrap();
+
+        let caps = actual
+            .find_match("zsh: permission denied: ./foo.sh")
+            .expect("expected a match");
+
+        assert_eq!(caps.positional[0], "permission denied: ./foo.sh");
+        assert_eq!(caps.positional[1], "foo.sh");
+        assert_eq!(caps.named.get("file").unwrap(), "foo.sh");
+        assert!(actual.find_match("no match here").is_none());
+    }
+
+    #[test]
+    fn reserved_capture_group_names_are_rejected() {
+        for reserved in ["working_dir", "captures"] {
+            let model_metadata = make_metadata(
+                "bad-capture-name",
+                "/foo/bar/file.yaml",
+                "/foo/bar",
+                "/some/work/dir",
+            );
+
+            let input = V1AlphaKnownError {
+                api_version: V1AlphaApiVersion::ScopeV1Alpha,
+                kind: KnownErrorKind::ScopeKnownError,
+                metadata: model_metadata,
+                spec: KnownErrorSpec {
+                    help: "some help".to_string(),
+                    pattern: KnownErrorPattern::Single(format!("error: (?<{reserved}>.*)")),
+                    fix: None,
+                },
+            };
+
+            let result = KnownError::try_from(input);
+            let msg = result.unwrap_err().to_string();
+            assert!(
+                msg.contains("reserved"),
+                "expected a 'reserved' error for capture name '{reserved}', got: {msg}"
+            );
+        }
+    }
+
+    #[test]
+    fn broken_fix_template_is_rejected_at_load_time() {
+        let model_metadata = make_metadata(
+            "broken-fix",
+            "/foo/bar/file.yaml",
+            "/foo/bar",
+            "/some/work/dir",
+        );
+
+        let input = V1AlphaKnownError {
+            api_version: V1AlphaApiVersion::ScopeV1Alpha,
+            kind: KnownErrorKind::ScopeKnownError,
+            metadata: model_metadata,
+            spec: KnownErrorSpec {
+                help: "some help".to_string(),
+                pattern: KnownErrorPattern::Single("some regex pattern".to_string()),
+                fix: Some(DoctorFixSpec {
+                    commands: vec!["echo {{ unterminated".to_string()],
+                    help_text: None,
+                    help_url: None,
+                    prompt: None,
+                }),
+            },
+        };
+
+        // The broken template must fail here, at config-load time, rather than only
+        // surfacing later when a matching line is actually intercepted.
+        assert!(KnownError::try_from(input).is_err());
     }
 }

--- a/src/shared/models/internal/mod.rs
+++ b/src/shared/models/internal/mod.rs
@@ -5,7 +5,7 @@ use crate::models::prelude::{
 use crate::shared::prelude::*;
 use anyhow::Result;
 use anyhow::anyhow;
-use minijinja::{Environment, context};
+use minijinja::Environment;
 use path_clean::PathClean;
 use serde_yaml::Value;
 use std::collections::{BTreeMap, VecDeque};
@@ -22,7 +22,9 @@ use self::upload_location::ReportUploadLocation;
 
 pub mod prelude {
     pub use super::ParsedConfig;
+    pub use super::RegexCaptures;
     pub use super::generate_env_vars;
+    pub use super::substitute_templates_with_captures;
     pub use super::{command::*, doctor_group::*, fix::*, known_error::*, upload_location::*};
 }
 
@@ -94,11 +96,44 @@ pub(crate) fn extract_command_path(parent_dir: &Path, exec: &str) -> String {
         .join(" ")
 }
 
+/// Text captured from a `ScopeKnownError` pattern match, made available to templates so
+/// help text and fix commands can be parameterized by the matched error line.
+///
+/// `positional` holds the regex's capture groups in order (index `0` is the whole match,
+/// exposed to templates as `{{ captures[0] }}`, `{{ captures[1] }}`, ...). `named` holds any
+/// named capture groups (e.g. `(?<file>.*)`), exposed directly as `{{ file }}`.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct RegexCaptures {
+    pub positional: Vec<String>,
+    pub named: BTreeMap<String, String>,
+}
+
 pub(crate) fn substitute_templates(work_dir: &str, input_str: &str) -> Result<String> {
+    substitute_templates_with_captures(work_dir, input_str, &RegexCaptures::default())
+}
+
+#[derive(serde::Serialize)]
+struct TemplateContext<'a> {
+    working_dir: &'a str,
+    captures: &'a [String],
+    #[serde(flatten)]
+    named: &'a BTreeMap<String, String>,
+}
+
+pub fn substitute_templates_with_captures(
+    work_dir: &str,
+    input_str: &str,
+    captures: &RegexCaptures,
+) -> Result<String> {
     let mut env = Environment::new();
     env.add_template("input_str", input_str)?;
     let template = env.get_template("input_str")?;
-    let result = template.render(context! { working_dir => work_dir })?;
+    let ctx = TemplateContext {
+        working_dir: work_dir,
+        captures: &captures.positional,
+        named: &captures.named,
+    };
+    let result = template.render(ctx)?;
 
     Ok(result)
 }
@@ -170,6 +205,89 @@ mod tests {
             let actual = substitute_templates(working_dir, command).unwrap();
 
             assert_eq!("/foo.sh".to_string(), actual)
+        }
+    }
+
+    mod substitute_templates_with_captures_spec {
+        use super::*;
+
+        #[test]
+        fn positional_capture_is_subbed() {
+            let working_dir = "/some/path";
+            let captures = RegexCaptures {
+                positional: vec!["whole match".to_string(), "foo.sh".to_string()],
+                named: BTreeMap::new(),
+            };
+
+            let actual = substitute_templates_with_captures(
+                working_dir,
+                "chmod +x {{ captures[1] }}",
+                &captures,
+            )
+            .unwrap();
+
+            assert_eq!("chmod +x foo.sh".to_string(), actual)
+        }
+
+        #[test]
+        fn named_capture_is_subbed() {
+            let working_dir = "/some/path";
+            let mut named = BTreeMap::new();
+            named.insert("file".to_string(), "foo.sh".to_string());
+            let captures = RegexCaptures {
+                positional: vec!["whole match".to_string(), "foo.sh".to_string()],
+                named,
+            };
+
+            let actual =
+                substitute_templates_with_captures(working_dir, "chmod +x {{ file }}", &captures)
+                    .unwrap();
+
+            assert_eq!("chmod +x foo.sh".to_string(), actual)
+        }
+
+        #[test]
+        fn missing_capture_renders_empty() {
+            let working_dir = "/some/path";
+            let captures = RegexCaptures::default();
+
+            let actual =
+                substitute_templates_with_captures(working_dir, "chmod +x {{ file }}", &captures)
+                    .unwrap();
+
+            assert_eq!("chmod +x ".to_string(), actual)
+        }
+
+        #[test]
+        fn working_dir_still_resolves_alongside_captures() {
+            let working_dir = "/some/path";
+            let mut named = BTreeMap::new();
+            named.insert("file".to_string(), "foo.sh".to_string());
+            let captures = RegexCaptures {
+                positional: vec!["whole match".to_string()],
+                named,
+            };
+
+            let actual = substitute_templates_with_captures(
+                working_dir,
+                "{{ working_dir }}/{{ file }}",
+                &captures,
+            )
+            .unwrap();
+
+            assert_eq!("/some/path/foo.sh".to_string(), actual)
+        }
+
+        #[test]
+        fn no_captures_matches_substitute_templates() {
+            let working_dir = "/some/path";
+            let command = "{{ working_dir }}/foo.sh";
+
+            let actual =
+                substitute_templates_with_captures(working_dir, command, &RegexCaptures::default())
+                    .unwrap();
+
+            assert_eq!(substitute_templates(working_dir, command).unwrap(), actual)
         }
     }
 }

--- a/tests/scope_intercept.rs
+++ b/tests/scope_intercept.rs
@@ -82,6 +82,56 @@ fn test_intercept_fix_succeeds_retry_fails() {
     helper.clean_work_dir();
 }
 
+// A fix with multiple commands must stop running commands after the first one fails,
+// rather than continuing through the rest of the list.
+#[test]
+fn test_intercept_fix_stops_after_first_command_fails() {
+    let helper = ScopeTestHelper::new(
+        "test_intercept_fix_stops_after_first_command_fails",
+        "intercept-known-error-multi-command-fix",
+    );
+
+    helper
+        .intercept_command(&[
+            "--yolo",
+            "--",
+            "bash",
+            "-c",
+            "echo 'trigger-multi-command-fix'; exit 1",
+        ])
+        .failure()
+        .stdout(predicate::str::contains(
+            "Known error 'multi-command-fix' found",
+        ))
+        .stdout(predicate::str::contains("SECOND_COMMAND_RAN").not());
+
+    helper.clean_work_dir();
+}
+
+// The pattern captures the missing filename from `cat`'s own error message and the fix
+// creates that exact file, proving the fix isn't hardcoded to one filename.
+#[test]
+fn test_intercept_fix_uses_captured_regex_group() {
+    let helper = ScopeTestHelper::new(
+        "test_intercept_fix_uses_captured_regex_group",
+        "intercept-known-error-capture",
+    );
+
+    helper
+        .intercept_command(&["--yolo", "cat", "wanted-name.txt"])
+        .success()
+        .stdout(predicate::str::contains(
+            "Known error 'missing-captured-file' found",
+        ))
+        .stdout(predicate::str::contains(
+            "The file 'wanted-name.txt' does not exist. Creating it now.",
+        ))
+        .stdout(predicate::str::contains("Fix succeeded, retrying command"))
+        .stdout(predicate::str::contains("ready"));
+
+    helper.clean_work_dir();
+}
+
 #[test]
 fn test_intercept_known_error_no_fix() {
     let helper = ScopeTestHelper::new(

--- a/tests/test-cases/intercept-known-error-capture/.scope/known-error.yaml
+++ b/tests/test-cases/intercept-known-error-capture/.scope/known-error.yaml
@@ -1,0 +1,13 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: missing-captured-file
+  description: Detects a missing file from the error message and creates that exact file
+spec:
+  pattern: "cat: (?<file>.*): No such file or directory"
+  help: "The file '{{ file }}' does not exist. Creating it now."
+  fix:
+    prompt:
+      text: "Create '{{ file }}'?"
+    commands:
+      - bash -c 'echo "ready" > {{ file }}'

--- a/tests/test-cases/intercept-known-error-multi-command-fix/.scope/known-error.yaml
+++ b/tests/test-cases/intercept-known-error-multi-command-fix/.scope/known-error.yaml
@@ -1,0 +1,12 @@
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: multi-command-fix
+  description: A fix with multiple commands where the first always fails
+spec:
+  pattern: "trigger-multi-command-fix"
+  help: Testing that a fix stops running commands after the first one fails.
+  fix:
+    commands:
+      - "false"
+      - "echo SECOND_COMMAND_RAN"


### PR DESCRIPTION
## Summary
- `ScopeKnownError` patterns can now capture text from the matched error line and reuse it in `help` text and in `fix`'s `commands`/`prompt`, via the existing minijinja `{{ }}` templating: positional groups as `{{ captures[1] }}` (index `0` is the whole match) and named groups like `(?<file>.*)` as `{{ file }}`. Closes #196.
- `KnownError` stores `Vec<Regex>` instead of a `RegexSet` (needed to pull capture groups out of a match) and the raw `DoctorFixSpec` instead of a pre-built `DoctorFix` — fix-building moves to match time, once captures are known, via new `_with_captures` sibling functions (`DoctorCommand::try_new_with_captures`, `DoctorCommands::from_commands_with_captures`, `DoctorFix::from_spec_with_captures`). The originals are unchanged thin wrappers, so `ScopeDoctorGroup` fixes are untouched.
- The fix is still eagerly validated at config-load time (rendered once with empty captures) so a broken template fails fast instead of only surfacing when a line actually matches.
- A capture group named `working_dir` or `captures` is rejected at load time, since it would otherwise silently shadow the reserved template variable of the same name.
- `help_text` rendering falls back to the raw string on a template error, since it predates this feature and may contain literal brace-like text that was never meant to be a template.
- Docs/schema/examples updated: doc comments on `KnownErrorPattern`/`KnownErrorSpec`, a new `examples/v1alpha/KnownErrorWithCapture.yaml`, and the generated `schema/*.json` (the docs site symlinks to these).

## Test plan
- [x] `cargo build`, `cargo test` (177 unit + all integration suites pass)
- [x] `cargo fmt --check`, `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] New integration fixture `tests/test-cases/intercept-known-error-capture/` (`test_intercept_fix_uses_captured_regex_group`) — captures a filename from a real error message and uses it, unmodified, in help text and the fix command
- [x] New integration fixture `tests/test-cases/intercept-known-error-multi-command-fix/` (`test_intercept_fix_stops_after_first_command_fails`) — confirms a multi-command fix stops after the first failing command; manually verified this test fails if that short-circuit is broken
- [x] Unit tests for capture extraction, reserved-name rejection, eager fix validation at load time, and template substitution (positional/named/missing/coexistence with `working_dir`)
- [x] Ran an independent code review + coverage + mutation testing pass; fixed everything that surfaced (reserved-name collision, help-text template crash, deferred fix validation, fmt drift, a dead `.expect()`, and one real mutation-testing gap in the fix short-circuit logic)