### PR TITLE
fix: make check optional on doctor group actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /.idea
+/mutants.out

--- a/docs/docs/models/ScopeDoctorGroup.mdx
+++ b/docs/docs/models/ScopeDoctorGroup.mdx
@@ -52,6 +52,11 @@ spec:
       fix:
         commands:
           - yarn install
+    - description: Always re-link the shims
+      name: relink-shims
+      fix:
+        commands:
+          - ./scripts/relink-shims.sh
 ```
 
 In the example above, there are two actions, the first ensures that node is operational.

--- a/examples/group-1.yaml
+++ b/examples/group-1.yaml
@@ -29,3 +29,8 @@ spec:
           - '*/*.txt'
         commands:
           - sleep infinity
+    - name: action3
+      description: foo3
+      fix:
+        commands:
+          - ./fix3.sh

--- a/examples/v1alpha/DoctorGroup.yaml
+++ b/examples/v1alpha/DoctorGroup.yaml
@@ -29,3 +29,8 @@ spec:
           - '*/*.txt'
         commands:
           - sleep infinity
+    - name: action3
+      description: foo3
+      fix:
+        commands:
+          - ./fix3.sh

--- a/schema/merged.json
+++ b/schema/merged.json
@@ -109,8 +109,15 @@
       "type": "object",
       "properties": {
         "check": {
-          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.",
-          "$ref": "#/$defs/DoctorCheckSpec"
+          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.\n\nWhen omitted, there is no check and the fix will always run.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DoctorCheckSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "description": {
           "description": "A description of this specific action, used for information to the users.",
@@ -142,8 +149,7 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
-        "check"
+        "name"
       ]
     },
     "DoctorGroupKind": {

--- a/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
+++ b/schema/v1alpha.com.github.scope.ScopeDoctorGroup.json
@@ -125,8 +125,15 @@
       "type": "object",
       "properties": {
         "check": {
-          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.",
-          "$ref": "#/$defs/DoctorCheckSpec"
+          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.\n\nWhen omitted, there is no check and the fix will always run.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DoctorCheckSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "description": {
           "description": "A description of this specific action, used for information to the users.",
@@ -158,8 +165,7 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
-        "check"
+        "name"
       ]
     },
     "DoctorGroupKind": {

--- a/schema/v1alpha.com.github.scope.ScopeKnownError.json
+++ b/schema/v1alpha.com.github.scope.ScopeKnownError.json
@@ -125,8 +125,15 @@
       "type": "object",
       "properties": {
         "check": {
-          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.",
-          "$ref": "#/$defs/DoctorCheckSpec"
+          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.\n\nWhen omitted, there is no check and the fix will always run.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DoctorCheckSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "description": {
           "description": "A description of this specific action, used for information to the users.",
@@ -158,8 +165,7 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
-        "check"
+        "name"
       ]
     },
     "DoctorGroupKind": {

--- a/schema/v1alpha.com.github.scope.ScopeReportLocation.json
+++ b/schema/v1alpha.com.github.scope.ScopeReportLocation.json
@@ -125,8 +125,15 @@
       "type": "object",
       "properties": {
         "check": {
-          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.",
-          "$ref": "#/$defs/DoctorCheckSpec"
+          "description": "The `check` run before `fix` (if provided). A check is used to determine if the fix needs\nto be executed, or fail the action if no fix is provided. If a fix is specified, the check\nwill re-execute to ensure that the fix applied correctly.\n\nWhen omitted, there is no check and the fix will always run.",
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DoctorCheckSpec"
+            },
+            {
+              "type": "null"
+            }
+          ]
         },
         "description": {
           "description": "A description of this specific action, used for information to the users.",
@@ -158,8 +165,7 @@
       },
       "additionalProperties": false,
       "required": [
-        "name",
-        "check"
+        "name"
       ]
     },
     "DoctorGroupKind": {

--- a/src/models/v1alpha/doctor_group.rs
+++ b/src/models/v1alpha/doctor_group.rs
@@ -9,7 +9,7 @@ use crate::models::{HelpMetadata, InternalScopeModel, ScopeModel};
 
 /// What needs to be checked before the action will run. `paths` will be checked first, then
 /// `commands`. If a `path` matches no files or the matching files have changed, the `command` will run.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 #[schemars(deny_unknown_fields)]
 pub struct DoctorCheckSpec {
@@ -78,7 +78,9 @@ pub struct DoctorGroupActionSpec {
     /// The `check` run before `fix` (if provided). A check is used to determine if the fix needs
     /// to be executed, or fail the action if no fix is provided. If a fix is specified, the check
     /// will re-execute to ensure that the fix applied correctly.
-    pub check: DoctorCheckSpec,
+    ///
+    /// When omitted, there is no check and the fix will always run.
+    pub check: Option<DoctorCheckSpec>,
 
     /// A fix defines how to fix the issue that a `check` is validating. When provided, will only
     /// run when the `check` "fails".

--- a/src/shared/models/internal/doctor_group.rs
+++ b/src/shared/models/internal/doctor_group.rs
@@ -112,7 +112,9 @@ fn parse_action(
         None => DoctorFix::empty(),
     };
 
-    let check_command = match spec_action.check.commands {
+    let check_spec = spec_action.check.unwrap_or_default();
+
+    let check_command = match check_spec.commands {
         Some(ref check) => Some(DoctorCommands::from_commands(
             containing_dir,
             &working_dir,
@@ -130,7 +132,7 @@ fn parse_action(
         fix,
         check: DoctorGroupActionCheck {
             command: check_command,
-            files: spec_action.check.paths.map(|paths| DoctorGroupCachePath {
+            files: check_spec.paths.map(|paths| DoctorGroupCachePath {
                 paths: paths
                     .iter() // TODO: should this be as_ref() still? Changed because type inference error
                     .map(|p| substitute_templates(working_dir.as_str(), p).unwrap()) // TODO: implement a function here, make it an early exit
@@ -162,6 +164,7 @@ mod tests {
 
         let dg = configs[0].get_doctor_group().unwrap();
         assert_eq!("foo", dg.metadata.name);
+        assert_eq!(3, dg.actions.len());
         assert_eq!(
             "/foo/bar/.scope/file.yaml",
             dg.metadata.annotations.file_path.unwrap()
@@ -209,5 +212,63 @@ mod tests {
                 }
             }
         );
+        assert_eq!(
+            dg.actions[2],
+            DoctorGroupAction {
+                name: "action3".to_string(),
+                required: true,
+                description: "foo3".to_string(),
+                fix: DoctorFix {
+                    command: Some(DoctorCommands::from(vec!["/foo/bar/.scope/fix3.sh"])),
+                    prompt: None,
+                    help_text: None,
+                    help_url: None,
+                },
+                check: DoctorGroupActionCheck {
+                    command: None,
+                    files: None,
+                }
+            }
+        );
+    }
+
+    /// Regression test for https://github.com/Gusto/scope/issues/153: `check` becoming
+    /// `Option<DoctorCheckSpec>` must not change how an explicit, empty `check: {}` (the
+    /// pre-existing "always run the fix" idiom) is parsed.
+    #[test]
+    fn omitted_check_and_empty_check_parse_identically() {
+        let work_dir = Path::new("/foo/bar");
+        let path = Path::new("/foo/bar/.scope/file.yaml");
+
+        let render = |check_yaml: &str| {
+            let text = format!(
+                r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: foo
+spec:
+  actions:
+    - name: action1
+{check_yaml}      fix:
+        commands:
+          - ./fix1.sh
+"#
+            );
+            let configs = parse_models_from_string(work_dir, path, &text).unwrap();
+            configs[0].get_doctor_group().unwrap().actions[0]
+                .check
+                .clone()
+        };
+
+        let omitted = render("");
+        let empty = render("      check: {}\n");
+        let expected = DoctorGroupActionCheck {
+            command: None,
+            files: None,
+        };
+
+        assert_eq!(expected, omitted);
+        assert_eq!(expected, empty);
     }
 }

--- a/tests/test-cases/fix-false/.scope/group.yaml
+++ b/tests/test-cases/fix-false/.scope/group.yaml
@@ -13,7 +13,6 @@ spec:
           - echo "fix ran"
     - name: run-always-not-required
       required: false
-      check: {}
       fix:
         commands:
           - echo "this always runs but isn't critical"


### PR DESCRIPTION
## Summary
- `check` on a `ScopeDoctorGroup` action is now `Option<DoctorCheckSpec>` instead of required, so omitting it entirely gives the same "always run the fix" behavior as the existing `check: {}` workaround — matching what the docs already claimed.
- Both maintainers agreed on this exact direction in the issue thread; this just implements it.
- Regenerated the JSON schemas (`check` dropped from `required`); `docs/static/schema` is a symlink to `schema/` so the docs site picks this up automatically.

## Backward compatibility
`check: {}` continues to behave identically — it still deserializes to the same `DoctorCheckSpec { paths: None, commands: None }` internally, and `parse_action`'s `unwrap_or_default()` produces the same value whether `check` was omitted or explicitly empty. Pinned by a new unit test (`omitted_check_and_empty_check_parse_identically`) and confirmed by the existing `run-always-required` fixture/integration test, which still uses `check: {}` and passes unmodified.

## Test plan
- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test` (249 tests, including a new unit test pinning `check: {}` vs omitted-`check` equivalence, and an integration-test fixture now exercising the omitted-check path end-to-end)
- [x] Manual smoke test of the exact MVCE from #153 (action with no `check` key) against the built binary
- [x] Independent QA pass (tests/lints/coverage/mutation testing via `gusto-rust:rust-review`) plus a workflow-backed adversarial code review — no unresolved findings

Closes #153