### PR TITLE
Log a WARN instead of silently dropping invalid ScopeKnownError config

### DIFF
--- a/src/bin/scope.rs
+++ b/src/bin/scope.rs
@@ -86,7 +86,7 @@ async fn main() {
 async fn run_subcommand(opts: Cli) -> i32 {
     let loaded_config = match opts.config.load_config().await {
         Err(e) => {
-            error!(target: "user", "Failed to load configuration: {}", e);
+            error!(target: "user", "Failed to load configuration: {:#}", e);
             return 2;
         }
         Ok(c) => c,

--- a/src/shared/config_load.rs
+++ b/src/shared/config_load.rs
@@ -1,5 +1,5 @@
-use crate::models::prelude::{ModelRoot, V1AlphaKnownError};
-use crate::models::{HelpMetadata, InternalScopeModel};
+use crate::models::HelpMetadata;
+use crate::models::prelude::ModelRoot;
 use crate::shared::RUN_ID_ENV_VAR;
 use crate::shared::directories;
 use crate::shared::models::prelude::{DoctorGroup, KnownError, ParsedConfig, ReportUploadLocation};
@@ -70,7 +70,7 @@ impl ConfigOptions {
         };
 
         let config_path = self.find_scope_paths(&working_dir);
-        let found_config = FoundConfig::new(self, working_dir, config_path).await?;
+        let found_config = FoundConfig::new(self, working_dir, config_path).await;
 
         debug!("Loaded config {:?}", found_config);
 
@@ -132,7 +132,7 @@ impl FoundConfig {
         config_options: &ConfigOptions,
         working_dir: PathBuf,
         config_path: Vec<PathBuf>,
-    ) -> Result<Self> {
+    ) -> Self {
         let default_path = std::env::var("PATH").unwrap_or_default();
 
         let mut config_path = config_path.to_vec();
@@ -164,31 +164,19 @@ impl FoundConfig {
             run_id: config_options.get_run_id(),
         };
 
-        let known_error_api_version = V1AlphaKnownError::int_api_version().to_lowercase();
-        let known_error_kind = V1AlphaKnownError::int_kind().to_lowercase();
         for raw_config in raw_config {
-            // A recognized `ScopeKnownError` that fails to build can never work as written, so
-            // that's a hard failure. Anything else (including a `ScopeKnownError` from an
-            // apiVersion this binary doesn't recognize) keeps the tolerant warn-and-continue
-            // behavior from #68/PR #69, since scope needs to tolerate config it doesn't yet
-            // understand.
-            let is_known_error = raw_config.kind.to_lowercase() == known_error_kind
-                && raw_config.api_version.to_lowercase() == known_error_api_version;
             let full_name = raw_config.full_name();
             let file_path = raw_config.file_path();
 
             match raw_config.try_into() {
                 Ok(value) => this.add_model(value),
-                Err(e) if is_known_error => {
-                    return Err(e.context(format!("Unable to load {full_name} from {file_path}")));
-                }
                 Err(e) => {
                     warn!(target: "user", "Unable to load {} from {} because {}", full_name.bold(), file_path, e);
                 }
             }
         }
 
-        Ok(this)
+        this
     }
 
     pub fn write_raw_config_to_disk(&self) -> Result<PathBuf> {
@@ -527,17 +515,34 @@ mod tests {
         build_config_path(nonexistent_path);
     }
 
-    /// Regression test for https://github.com/Gusto/scope/issues/344: a `ScopeKnownError` that
-    /// fails its own validation (here, a reserved capture group name) must abort config load with
-    /// a diagnosable error, rather than silently registering nothing.
-    #[tokio::test]
-    async fn invalid_known_error_aborts_config_load() {
+    /// Writes each `(file_name, contents)` pair under a fresh temp `.scope` dir and loads it
+    /// through the real `FoundConfig::new` entrypoint.
+    async fn found_config_from_files(files: &[(&str, &str)]) -> FoundConfig {
         let temp_dir = tempdir().unwrap();
         let scope_dir = temp_dir.path().join(".scope");
         fs::create_dir_all(&scope_dir).unwrap();
-        fs::write(
-            scope_dir.join("known-error.yaml"),
-            r#"
+        for (name, contents) in files {
+            fs::write(scope_dir.join(name), contents).unwrap();
+        }
+
+        let config_options = ConfigOptions::parse_from(["scope"]);
+        FoundConfig::new(
+            &config_options,
+            temp_dir.path().to_path_buf(),
+            vec![scope_dir],
+        )
+        .await
+    }
+
+    /// Regression test for https://github.com/Gusto/scope/issues/344: a `ScopeKnownError` that
+    /// fails its own validation (here, a reserved capture group name) must be logged instead of
+    /// silently registering nothing, while a valid known error in the same directory still loads.
+    #[tokio::test]
+    async fn invalid_known_error_warns_and_continues() {
+        let found_config = found_config_from_files(&[
+            (
+                "bad-known-error.yaml",
+                r#"
 apiVersion: scope.github.com/v1alpha
 kind: ScopeKnownError
 metadata:
@@ -546,38 +551,36 @@ spec:
   pattern: "boom: (?<working_dir>.*)"
   help: "should never load"
 "#,
-        )
-        .unwrap();
-
-        let config_options = ConfigOptions::parse_from(["scope"]);
-        let result = FoundConfig::new(
-            &config_options,
-            temp_dir.path().to_path_buf(),
-            vec![scope_dir],
-        )
+            ),
+            (
+                "good-known-error.yaml",
+                r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: good
+spec:
+  pattern: "boom"
+  help: "fine"
+"#,
+            ),
+        ])
         .await;
 
-        let err = result.expect_err("invalid ScopeKnownError should abort config load");
-        let message = format!("{err:#}");
-        assert!(message.contains("reserved"), "unexpected error: {message}");
-        assert!(
-            message.contains("ScopeKnownError/bad-reserved"),
-            "unexpected error: {message}"
-        );
+        assert!(!found_config.known_error.contains_key("bad-reserved"));
+        assert!(found_config.known_error.contains_key("good"));
     }
 
-    /// Companion to `invalid_known_error_aborts_config_load`: a `ScopeDoctorGroup` that fails to
+    /// Companion to `invalid_known_error_warns_and_continues`: a `ScopeDoctorGroup` that fails to
     /// build (here, a broken fix template) should warn and be dropped, not abort the whole load —
-    /// that's the pre-existing, intentional behavior from #68/PR #69. A valid group in the same
-    /// directory must still load, proving this is "drop the bad one", not "load nothing".
+    /// the pre-existing, intentional behavior from #68/PR #69. A valid group in the same directory
+    /// must still load, proving this is "drop the bad one", not "load nothing".
     #[tokio::test]
     async fn invalid_doctor_group_warns_and_continues() {
-        let temp_dir = tempdir().unwrap();
-        let scope_dir = temp_dir.path().join(".scope");
-        fs::create_dir_all(&scope_dir).unwrap();
-        fs::write(
-            scope_dir.join("broken-group.yaml"),
-            r#"
+        let found_config = found_config_from_files(&[
+            (
+                "broken-group.yaml",
+                r#"
 apiVersion: scope.github.com/v1alpha
 kind: ScopeDoctorGroup
 metadata:
@@ -590,11 +593,10 @@ spec:
         commands:
           - "echo {{ unterminated"
 "#,
-        )
-        .unwrap();
-        fs::write(
-            scope_dir.join("good-group.yaml"),
-            r#"
+            ),
+            (
+                "good-group.yaml",
+                r#"
 apiVersion: scope.github.com/v1alpha
 kind: ScopeDoctorGroup
 metadata:
@@ -607,108 +609,11 @@ spec:
         commands:
           - echo fine
 "#,
-        )
-        .unwrap();
-
-        let config_options = ConfigOptions::parse_from(["scope"]);
-        let found_config = FoundConfig::new(
-            &config_options,
-            temp_dir.path().to_path_buf(),
-            vec![scope_dir],
-        )
-        .await
-        .expect("a broken ScopeDoctorGroup should warn and continue, not abort");
+            ),
+        ])
+        .await;
 
         assert!(!found_config.doctor_group.contains_key("broken"));
         assert!(found_config.doctor_group.contains_key("good"));
-    }
-
-    /// A `ScopeKnownError` from an apiVersion this binary doesn't recognize must NOT be treated as
-    /// a "recognized but invalid" known error — it's the same "config we don't yet understand"
-    /// case as an unrecognized kind, and should warn-and-continue rather than aborting the load.
-    /// (A future scope version adding a new known-error apiVersion must not break older binaries
-    /// running against a fleet-wide shared config directory.)
-    #[tokio::test]
-    async fn unrecognized_api_version_known_error_warns_and_continues() {
-        let temp_dir = tempdir().unwrap();
-        let scope_dir = temp_dir.path().join(".scope");
-        fs::create_dir_all(&scope_dir).unwrap();
-        fs::write(
-            scope_dir.join("known-error.yaml"),
-            r#"
-apiVersion: scope.github.com/v1beta
-kind: ScopeKnownError
-metadata:
-  name: future-version
-spec:
-  pattern: "boom"
-  help: "from a version this binary doesn't understand"
-"#,
-        )
-        .unwrap();
-
-        let config_options = ConfigOptions::parse_from(["scope"]);
-        let found_config = FoundConfig::new(
-            &config_options,
-            temp_dir.path().to_path_buf(),
-            vec![scope_dir],
-        )
-        .await
-        .expect("an unrecognized apiVersion should warn and continue, not abort");
-
-        assert!(found_config.known_error.is_empty());
-    }
-
-    /// A genuinely invalid `ScopeKnownError` aborts the whole config load, even when a perfectly
-    /// valid `ScopeDoctorGroup` sits in the same directory — this is the documented tradeoff of
-    /// treating known-error validation failures as fatal (see #344).
-    #[tokio::test]
-    async fn invalid_known_error_aborts_load_of_otherwise_valid_config() {
-        let temp_dir = tempdir().unwrap();
-        let scope_dir = temp_dir.path().join(".scope");
-        fs::create_dir_all(&scope_dir).unwrap();
-        fs::write(
-            scope_dir.join("good-group.yaml"),
-            r#"
-apiVersion: scope.github.com/v1alpha
-kind: ScopeDoctorGroup
-metadata:
-  name: good
-spec:
-  actions:
-    - name: action1
-      check: {}
-      fix:
-        commands:
-          - echo fine
-"#,
-        )
-        .unwrap();
-        fs::write(
-            scope_dir.join("bad-known-error.yaml"),
-            r#"
-apiVersion: scope.github.com/v1alpha
-kind: ScopeKnownError
-metadata:
-  name: bad-reserved
-spec:
-  pattern: "boom: (?<working_dir>.*)"
-  help: "should never load"
-"#,
-        )
-        .unwrap();
-
-        let config_options = ConfigOptions::parse_from(["scope"]);
-        let result = FoundConfig::new(
-            &config_options,
-            temp_dir.path().to_path_buf(),
-            vec![scope_dir],
-        )
-        .await;
-
-        assert!(
-            result.is_err(),
-            "an invalid known error must abort the whole load, even alongside valid config"
-        );
     }
 }

--- a/src/shared/config_load.rs
+++ b/src/shared/config_load.rs
@@ -1,5 +1,5 @@
-use crate::models::HelpMetadata;
-use crate::models::prelude::ModelRoot;
+use crate::models::prelude::{ModelRoot, V1AlphaKnownError};
+use crate::models::{HelpMetadata, InternalScopeModel};
 use crate::shared::RUN_ID_ENV_VAR;
 use crate::shared::directories;
 use crate::shared::models::prelude::{DoctorGroup, KnownError, ParsedConfig, ReportUploadLocation};
@@ -70,7 +70,7 @@ impl ConfigOptions {
         };
 
         let config_path = self.find_scope_paths(&working_dir);
-        let found_config = FoundConfig::new(self, working_dir, config_path).await;
+        let found_config = FoundConfig::new(self, working_dir, config_path).await?;
 
         debug!("Loaded config {:?}", found_config);
 
@@ -132,7 +132,7 @@ impl FoundConfig {
         config_options: &ConfigOptions,
         working_dir: PathBuf,
         config_path: Vec<PathBuf>,
-    ) -> Self {
+    ) -> Result<Self> {
         let default_path = std::env::var("PATH").unwrap_or_default();
 
         let mut config_path = config_path.to_vec();
@@ -164,13 +164,31 @@ impl FoundConfig {
             run_id: config_options.get_run_id(),
         };
 
+        let known_error_api_version = V1AlphaKnownError::int_api_version().to_lowercase();
+        let known_error_kind = V1AlphaKnownError::int_kind().to_lowercase();
         for raw_config in raw_config {
-            if let Ok(value) = raw_config.try_into() {
-                this.add_model(value);
+            // A recognized `ScopeKnownError` that fails to build can never work as written, so
+            // that's a hard failure. Anything else (including a `ScopeKnownError` from an
+            // apiVersion this binary doesn't recognize) keeps the tolerant warn-and-continue
+            // behavior from #68/PR #69, since scope needs to tolerate config it doesn't yet
+            // understand.
+            let is_known_error = raw_config.kind.to_lowercase() == known_error_kind
+                && raw_config.api_version.to_lowercase() == known_error_api_version;
+            let full_name = raw_config.full_name();
+            let file_path = raw_config.file_path();
+
+            match raw_config.try_into() {
+                Ok(value) => this.add_model(value),
+                Err(e) if is_known_error => {
+                    return Err(e.context(format!("Unable to load {full_name} from {file_path}")));
+                }
+                Err(e) => {
+                    warn!(target: "user", "Unable to load {} from {} because {}", full_name.bold(), file_path, e);
+                }
             }
         }
 
-        this
+        Ok(this)
     }
 
     pub fn write_raw_config_to_disk(&self) -> Result<PathBuf> {
@@ -507,5 +525,190 @@ mod tests {
     fn test_build_config_path_nonexistent_directory() {
         let nonexistent_path = Path::new("/this/path/does/not/exist/hopefully");
         build_config_path(nonexistent_path);
+    }
+
+    /// Regression test for https://github.com/Gusto/scope/issues/344: a `ScopeKnownError` that
+    /// fails its own validation (here, a reserved capture group name) must abort config load with
+    /// a diagnosable error, rather than silently registering nothing.
+    #[tokio::test]
+    async fn invalid_known_error_aborts_config_load() {
+        let temp_dir = tempdir().unwrap();
+        let scope_dir = temp_dir.path().join(".scope");
+        fs::create_dir_all(&scope_dir).unwrap();
+        fs::write(
+            scope_dir.join("known-error.yaml"),
+            r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: bad-reserved
+spec:
+  pattern: "boom: (?<working_dir>.*)"
+  help: "should never load"
+"#,
+        )
+        .unwrap();
+
+        let config_options = ConfigOptions::parse_from(["scope"]);
+        let result = FoundConfig::new(
+            &config_options,
+            temp_dir.path().to_path_buf(),
+            vec![scope_dir],
+        )
+        .await;
+
+        let err = result.expect_err("invalid ScopeKnownError should abort config load");
+        let message = format!("{err:#}");
+        assert!(message.contains("reserved"), "unexpected error: {message}");
+        assert!(
+            message.contains("ScopeKnownError/bad-reserved"),
+            "unexpected error: {message}"
+        );
+    }
+
+    /// Companion to `invalid_known_error_aborts_config_load`: a `ScopeDoctorGroup` that fails to
+    /// build (here, a broken fix template) should warn and be dropped, not abort the whole load —
+    /// that's the pre-existing, intentional behavior from #68/PR #69. A valid group in the same
+    /// directory must still load, proving this is "drop the bad one", not "load nothing".
+    #[tokio::test]
+    async fn invalid_doctor_group_warns_and_continues() {
+        let temp_dir = tempdir().unwrap();
+        let scope_dir = temp_dir.path().join(".scope");
+        fs::create_dir_all(&scope_dir).unwrap();
+        fs::write(
+            scope_dir.join("broken-group.yaml"),
+            r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: broken
+spec:
+  actions:
+    - name: action1
+      check: {}
+      fix:
+        commands:
+          - "echo {{ unterminated"
+"#,
+        )
+        .unwrap();
+        fs::write(
+            scope_dir.join("good-group.yaml"),
+            r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: good
+spec:
+  actions:
+    - name: action1
+      check: {}
+      fix:
+        commands:
+          - echo fine
+"#,
+        )
+        .unwrap();
+
+        let config_options = ConfigOptions::parse_from(["scope"]);
+        let found_config = FoundConfig::new(
+            &config_options,
+            temp_dir.path().to_path_buf(),
+            vec![scope_dir],
+        )
+        .await
+        .expect("a broken ScopeDoctorGroup should warn and continue, not abort");
+
+        assert!(!found_config.doctor_group.contains_key("broken"));
+        assert!(found_config.doctor_group.contains_key("good"));
+    }
+
+    /// A `ScopeKnownError` from an apiVersion this binary doesn't recognize must NOT be treated as
+    /// a "recognized but invalid" known error — it's the same "config we don't yet understand"
+    /// case as an unrecognized kind, and should warn-and-continue rather than aborting the load.
+    /// (A future scope version adding a new known-error apiVersion must not break older binaries
+    /// running against a fleet-wide shared config directory.)
+    #[tokio::test]
+    async fn unrecognized_api_version_known_error_warns_and_continues() {
+        let temp_dir = tempdir().unwrap();
+        let scope_dir = temp_dir.path().join(".scope");
+        fs::create_dir_all(&scope_dir).unwrap();
+        fs::write(
+            scope_dir.join("known-error.yaml"),
+            r#"
+apiVersion: scope.github.com/v1beta
+kind: ScopeKnownError
+metadata:
+  name: future-version
+spec:
+  pattern: "boom"
+  help: "from a version this binary doesn't understand"
+"#,
+        )
+        .unwrap();
+
+        let config_options = ConfigOptions::parse_from(["scope"]);
+        let found_config = FoundConfig::new(
+            &config_options,
+            temp_dir.path().to_path_buf(),
+            vec![scope_dir],
+        )
+        .await
+        .expect("an unrecognized apiVersion should warn and continue, not abort");
+
+        assert!(found_config.known_error.is_empty());
+    }
+
+    /// A genuinely invalid `ScopeKnownError` aborts the whole config load, even when a perfectly
+    /// valid `ScopeDoctorGroup` sits in the same directory — this is the documented tradeoff of
+    /// treating known-error validation failures as fatal (see #344).
+    #[tokio::test]
+    async fn invalid_known_error_aborts_load_of_otherwise_valid_config() {
+        let temp_dir = tempdir().unwrap();
+        let scope_dir = temp_dir.path().join(".scope");
+        fs::create_dir_all(&scope_dir).unwrap();
+        fs::write(
+            scope_dir.join("good-group.yaml"),
+            r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeDoctorGroup
+metadata:
+  name: good
+spec:
+  actions:
+    - name: action1
+      check: {}
+      fix:
+        commands:
+          - echo fine
+"#,
+        )
+        .unwrap();
+        fs::write(
+            scope_dir.join("bad-known-error.yaml"),
+            r#"
+apiVersion: scope.github.com/v1alpha
+kind: ScopeKnownError
+metadata:
+  name: bad-reserved
+spec:
+  pattern: "boom: (?<working_dir>.*)"
+  help: "should never load"
+"#,
+        )
+        .unwrap();
+
+        let config_options = ConfigOptions::parse_from(["scope"]);
+        let result = FoundConfig::new(
+            &config_options,
+            temp_dir.path().to_path_buf(),
+            vec![scope_dir],
+        )
+        .await;
+
+        assert!(
+            result.is_err(),
+            "an invalid known error must abort the whole load, even alongside valid config"
+        );
     }
 }

--- a/src/shared/models/internal/mod.rs
+++ b/src/shared/models/internal/mod.rs
@@ -1,3 +1,4 @@
+use crate::models::HelpMetadata;
 use crate::models::InternalScopeModel;
 use crate::models::prelude::{
     ModelRoot, V1AlphaDoctorGroup, V1AlphaKnownError, V1AlphaReportLocation,
@@ -63,18 +64,21 @@ impl TryFrom<ModelRoot<Value>> for ParsedConfig {
     type Error = anyhow::Error;
 
     fn try_from(value: ModelRoot<Value>) -> Result<Self, Self::Error> {
-        if let Ok(Some(known)) = V1AlphaDoctorGroup::known_type(&value) {
+        if let Some(known) = V1AlphaDoctorGroup::known_type(&value)? {
             return Ok(ParsedConfig::DoctorGroup(DoctorGroup::try_from(known)?));
         }
-        if let Ok(Some(known)) = V1AlphaKnownError::known_type(&value) {
+        if let Some(known) = V1AlphaKnownError::known_type(&value)? {
             return Ok(ParsedConfig::KnownError(KnownError::try_from(known)?));
         }
-        if let Ok(Some(known)) = V1AlphaReportLocation::known_type(&value) {
+        if let Some(known) = V1AlphaReportLocation::known_type(&value)? {
             return Ok(ParsedConfig::ReportUpload(ReportUploadLocation::try_from(
                 known,
             )?));
         }
-        Err(anyhow!("Error was know a known type"))
+        Err(anyhow!(
+            "'{}' did not match the apiVersion/kind of any known resource",
+            value.full_name()
+        ))
     }
 }
 


### PR DESCRIPTION
## Summary

Fixes #344. `Config::new` (now `FoundConfig::new`) converted each raw parsed
config document into its typed model via `try_into()` and silently discarded
the `Err` case with zero logging — a `ScopeKnownError` using a reserved
capture group name, or shipping a broken `{{ }}` fix template, would just
vanish with no signal, and the tool would report "No known errors found" as
if the config didn't exist at all.

The issue thread initially discussed making a `ScopeKnownError` conversion
failure a hard failure that aborts config loading entirely, since a
recognized-but-invalid known error can never work as written. After
implementing that, we reconsidered: aborting the whole config load meant a
single broken known-error file anywhere in a fleet-wide shared `.scope`
directory would disable known-error matching (and `scope-intercept`'s
auto-fix) for every *unrelated* known error too, and would block
`scope doctor`/`list`/`report` outright with exit code 2 — too large a blast
radius for one bad file.

So the final behavior: **every** kind (`ScopeKnownError`, `ScopeDoctorGroup`,
etc.) now logs a `warn!(target: "user", ...)` naming the file and the cause
when it fails to convert, and is dropped — the config load itself always
succeeds, same as before #344, just no longer silently. This preserves the
existing tolerant philosophy from #68/PR #69 uniformly across all kinds,
while finally giving the "at minimum, log it" signal the issue asked for.

Also fixed along the way, since silence had been hiding it:
- `ParsedConfig::try_from` (`src/shared/models/internal/mod.rs`) used
  `if let Ok(Some(known)) = ...known_type(...)`, silently swallowing real
  deserialization errors (e.g. a missing required field) behind a generic,
  typo'd `"Error was know a known type"` message. Real errors now propagate
  via `?`, so the new warn logs actually show the useful underlying cause.
- `scope.rs`'s config-load error log used `{}` instead of `{:#}`, which for
  a `.context()`-wrapped anyhow error prints only the outermost message and
  drops the real cause. Fixed for the "unable to get a working dir" path
  that can still fail there.

## Test plan

- [x] `cargo test` — full suite passes, including 2 new unit tests in
      `src/shared/config_load.rs` (via a shared `found_config_from_files`
      test helper) covering: a bad known error warning-and-dropping while a
      valid known error in the same directory still loads, and the same for
      a bad doctor group alongside a valid one.
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manually reproduced the issue's MVCE against `scope-intercept`: a
      broken known-error file now logs
      `WARN Unable to load ScopeKnownError/bad-reserved from <path> because
      known error '...' has a pattern with a capture group named 'captures',
      which is reserved for template substitution`, while a second, valid
      known error in the same directory still matches and reports correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)