### PR TITLE
Fix symlink attack via predictable /tmp path in write_raw_config_to_disk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ sha256 = "1.6.0"
 shellexpand = "3.1.2"
 strip-ansi-escapes = "0.2.1"
 strum = { version = "0.28", features = ["derive"] }
+tempfile = "3.27"
 thiserror = "2.0.18"
 time = { version = "0.3", features = ["macros", "formatting", "local-offset"] }
 tokio = { version = "1", features = ["full"] }
@@ -80,7 +81,6 @@ assert_cmd = "2.2.2"
 assert_fs = "1.1.4"
 nix = { version = "0.31", features = ["signal", "process"] }
 predicates = "3.1.4"
-tempfile = "3.27"
 wait-timeout = "0.2"
 
 [build-dependencies]

--- a/src/shared/config_load.rs
+++ b/src/shared/config_load.rs
@@ -13,7 +13,7 @@ use serde_yaml::{Deserializer, Value};
 
 use std::collections::BTreeMap;
 use std::ffi::OsStr;
-use std::fs::{self, File};
+use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use tracing::{debug, error, info, warn};
@@ -176,16 +176,17 @@ impl FoundConfig {
     pub fn write_raw_config_to_disk(&self) -> Result<PathBuf> {
         let json = serde_json::to_string(&self.raw_config)?;
         let json_bytes = json.as_bytes();
-        let file_path = PathBuf::from_iter(vec![
-            "/tmp",
-            "scope",
-            &format!("config-{}.json", self.run_id),
-        ]);
+
+        fs::create_dir_all("/tmp/scope")?;
+        let mut file = tempfile::Builder::new()
+            .prefix("config-")
+            .suffix(".json")
+            .tempfile_in("/tmp/scope")?;
+        file.write_all(json_bytes)?;
+
+        let (_, file_path) = file.keep()?;
 
         debug!("Merged config destination is to {}", file_path.display());
-
-        let mut file = File::create(&file_path)?;
-        file.write_all(json_bytes)?;
 
         Ok(file_path)
     }


### PR DESCRIPTION
## Summary
- `write_raw_config_to_disk` wrote the serialized raw config to `/tmp/scope/config-{run_id}.json` via plain `File::create`, which follows symlinks
- `run_id` is attacker/user-controllable via `--run-id` or `SCOPE_RUN_ID`, making the exact path predictable ahead of time; on a shared multi-user box or CI runner, an attacker could pre-plant a symlink there to have scope overwrite an arbitrary file
- Replaced with `tempfile::Builder` to create a securely-generated, unpredictable file under `/tmp/scope`, persisted via `NamedTempFile::keep()` so it survives past this function (it's read by a child process spawned right after in `exec_sub_command`)
- Moved `tempfile` from `[dev-dependencies]` to `[dependencies]` in `Cargo.toml` since it's now needed at runtime

DryRun Security finding surfaced during review of #356 (that PR's own diff is untouched here; this fixes a pre-existing issue in the surrounding file that the security scanner flagged while scanning the whole changed file).

## Test plan
- [x] `cargo build`
- [x] `cargo test` (full suite, 195+ tests pass)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Manually verified: ran `scope external` against the `tests/test-cases/command-paths` fixture with an instrumented script; confirmed `$SCOPE_CONFIG_JSON` points to a randomly-named file (not `run_id`-derived), created with `0600` permissions, containing valid config JSON readable by the child process